### PR TITLE
Simplify looking up user defaults from params namespace

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -5,17 +5,9 @@ class memcached(
   $listen_ip       = '0.0.0.0',
   $tcp_port        = '11211',
   $udp_port        = '11211',
-  $user            = '',
+  $user            = $::memcached::params::user,
   $max_connections = '8192'
-) {
-
-  include memcached::params
-
-  if $user == '' {
-    $user_real = $memcached::params::user
-  } else {
-    $user_real = $user
-  }
+) inherits memcached::params {
 
   package { $memcached::params::package_name:
     ensure => $package_ensure,

--- a/templates/memcached.conf.erb
+++ b/templates/memcached.conf.erb
@@ -26,7 +26,7 @@ logfile <%= logfile %>
 -U <%= udp_port %>
 
 # Run daemon as user
--u <%= user_real %>
+-u <%= user %>
 
 # Limit the number of simultaneous incoming connections.
 -c <%= max_connections %>

--- a/templates/memcached_sysconfig.erb
+++ b/templates/memcached_sysconfig.erb
@@ -1,5 +1,5 @@
 PORT="<%= udp_port %>"
-USER="<%= user_real %>"
+USER="<%= user %>"
 MAXCONN="<%= max_connections %>"
 CACHESIZE="<%= max_memory %>"
 OPTIONS=""


### PR DESCRIPTION
This commit simplifies the process by which the default
value of $user is determined when not provided.

The memcached class inherits from the params class so
that the params class defaults are accessible as
parameter defaults.

It is worth noting that this code will not work with versions
2.6.0 -> 2.6.5

It is also worth noting that this will probably just be a
temporary refactor until hiera becomes more pervasive.
