### PR TITLE
Using $::osfamily to make it work on RedHat derivatives

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -1,13 +1,13 @@
 class memcached::params {
-  case $::operatingsystem {
-    ubuntu, debian: {
+  case $::osfamily {
+    'Debian': {
       $package_name = 'memcached'
       $service_name = 'memcached'
       $config_file  = '/etc/memcached.conf'
       $config_tmpl  = "${module_name}/memcached.conf.erb"
       $user = 'nobody'
     }
-    centos, redhat, fedora: {
+    'RedHat': {
       $package_name = 'memcached'
       $service_name = 'memcached'
       $config_file = '/etc/sysconfig/memcached'


### PR DESCRIPTION
... such as Scientific Linux CERN :)
