### PR TITLE
Remove a trailing comma for compatibility with puppet 2.6

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -8,7 +8,7 @@ class memcached(
   $user            = $::memcached::params::user,
   $max_connections = '8192',
   $verbosity       = undef,
-  $unix_socket     = undef,
+  $unix_socket     = undef
 ) inherits memcached::params {
 
   package { $memcached::params::package_name:


### PR DESCRIPTION
Support for trailing commas in paramater lists wasn't added until sometime in the 2.7 timeframe. The memcached module otherwise appears to work with 2.6.9
