### PR TITLE
Enrich memory variables: allow percents & add lock flag

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 pkg/
 *.swp
+/metadata.json

--- a/README.md
+++ b/README.md
@@ -7,15 +7,23 @@ Manage memcached via Puppet
 
 ### Use roughly 90% of memory
 
-```
+```ruby
     class { 'memcached': }
 ```
 
 ### Set a fixed memory limit in MB
 
-```
+```ruby
     class { 'memcached':
       max_memory => 2048
+    }
+```
+
+### Use 12% of available memory
+
+```ruby
+    class { 'memcached':
+      max_memory => '12%'
     }
 ```
 
@@ -27,3 +35,4 @@ Manage memcached via Puppet
 * $udp_port = 11211
 * $user = '' (OS specific setting, see params.pp)
 * $max_connections = 8192
+* $lock_memory = false (WARNING: good if used intelligently, google for -k key)

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,7 +1,8 @@
 class memcached(
   $package_ensure  = 'present',
   $logfile         = '/var/log/memcached.log',
-  $max_memory      = false,
+  $max_memory      = '95%',
+  $lock_memory     = false,
   $listen_ip       = '0.0.0.0',
   $tcp_port        = 11211,
   $udp_port        = 11211,
@@ -10,6 +11,8 @@ class memcached(
   $verbosity       = undef,
   $unix_socket     = undef
 ) inherits memcached::params {
+
+  $real_max_memory = template("$module_name/real_max_memory.erb")
 
   package { $memcached::params::package_name:
     ensure => $package_ensure,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -4,14 +4,14 @@ class memcached::params {
       $package_name = 'memcached'
       $service_name = 'memcached'
       $config_file  = '/etc/memcached.conf'
-      $config_tmpl  = "${module_name}/memcached.conf.erb"
+      $config_tmpl  = "$module_name/memcached.conf.erb"
       $user = 'nobody'
     }
     'RedHat': {
       $package_name = 'memcached'
       $service_name = 'memcached'
       $config_file  = '/etc/sysconfig/memcached'
-      $config_tmpl  = "${module_name}/memcached_sysconfig.erb"
+      $config_tmpl  = "$module_name/memcached_sysconfig.erb"
       $user = 'memcached'
     }
     default: {

--- a/templates/memcached.conf.erb
+++ b/templates/memcached.conf.erb
@@ -7,7 +7,7 @@
 -P /var/run/memcached.pid
 
 # Log memcached's output
-logfile <%= logfile %>
+logfile <%= logfile -%>
 
 <% if @verbosity -%>
 # Verbosity
@@ -15,17 +15,17 @@ logfile <%= logfile %>
 <% end -%>
 
 # Use <num> MB memory max to use for object storage.
-<% if max_memory -%>
--m <%= max_memory %>
-<% else -%>
--m <%= ((memorysize.to_f*1024)*0.95).floor %>
+-m <%= real_max_memory %>
+
+<% if @lock_memory -%>
+# Lock down all paged memory.  There is a limit on how much memory you may lock.
+-k
 <% end -%>
 
 <% if @unix_socket -%>
 # UNIX socket path to listen on
 -s <%= unix_socket %>
 <% else -%>
-
 # IP to listen on
 -l <%= listen_ip %>
 

--- a/templates/memcached_sysconfig.erb
+++ b/templates/memcached_sysconfig.erb
@@ -1,5 +1,20 @@
-PORT="<%= udp_port %>"
+PORT="<%= tcp_port %>"
 USER="<%= user %>"
 MAXCONN="<%= max_connections %>"
-CACHESIZE="<%= max_memory %>"
-OPTIONS=""
+CACHESIZE="<%= real_max_memory %>"
+OPTIONS="<%
+result = []
+if @verbosity
+  result << '-' + verbosity
+end
+if @lock_memory
+  result << '-k'
+end
+if @listen_ip
+  result << '-l ' + listen_ip
+end
+if @udp_port
+  result << '-U ' + udp_port
+end
+result << '-t ' + processorcount
+-%><%= result.join(' ') -%>"

--- a/templates/real_max_memory.erb
+++ b/templates/real_max_memory.erb
@@ -1,0 +1,20 @@
+<%
+result_in_MB = 0
+if max_memory and ! max_memory.to_s.end_with?('%')
+  result_in_MB = max_memory.to_i
+else
+  mem, unit = scope.lookupvar('::memorysize').split
+  mem = mem.to_f
+  # Normalize mem to bytes
+  # @see https://groups.google.com/forum/?fromgroups=#!topic/puppet-users/8cBona2TeFM
+  case unit
+    when nil:  mem *= (1 <<  0)
+    when 'kB': mem *= (1 << 10)
+    when 'MB': mem *= (1 << 20)
+    when 'GB': mem *= (1 << 30)
+    when 'TB': mem *= (1 << 40)
+  end
+  max_memory_percent = max_memory ? max_memory : '95%'
+  result_in_MB = ( (mem.to_f / (1 << 20) ) * (max_memory_percent.to_f / 100.0) ).floor
+end
+%><%= result_in_MB -%>


### PR DESCRIPTION
Calculate max memory value in standalone place
- Fix memorysize fact issue (when it's not "nnn MB")
- Allow false, which is converted to 95%
- Reuse value in redhat`s config
- Allow percents of available memory
- Which allows us improved config for RedHat family

Little things
- Update documentation: add example with memory
- Add metadata.json to igonore -- eclipse loves to create one
