### PR TITLE
New parameter '$install_dev' to install development headers.

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,3 +37,4 @@ Manage memcached via Puppet
 * $user = '' (OS specific setting, see params.pp)
 * $max_connections = 8192
 * $lock_memory = false (WARNING: good if used intelligently, google for -k key)
+* $install_dev = false (TRUE if 'libmemcached-dev' package should be installed)

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -9,11 +9,19 @@ class memcached(
   $user            = $::memcached::params::user,
   $max_connections = '8192',
   $verbosity       = undef,
-  $unix_socket     = undef
+  $unix_socket     = undef,
+  $install_dev     = false
 ) inherits memcached::params {
 
   package { $memcached::params::package_name:
     ensure => $package_ensure,
+  }
+
+  if $install_dev {
+    package { $memcached::params::dev_package_name:
+      ensure  => $package_ensure,
+      require => Package[$memcached::params::package_name]
+    }
   }
 
   file { $memcached::params::config_file:

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -1,18 +1,20 @@
 class memcached::params {
   case $::osfamily {
     'Debian': {
-      $package_name = 'memcached'
-      $service_name = 'memcached'
-      $config_file  = '/etc/memcached.conf'
-      $config_tmpl  = "$module_name/memcached.conf.erb"
-      $user = 'nobody'
+      $package_name     = 'memcached'
+      $service_name     = 'memcached'
+      $dev_package_name = 'libmemcached-dev'
+      $config_file      = '/etc/memcached.conf'
+      $config_tmpl      = "$module_name/memcached.conf.erb"
+      $user             = 'nobody'
     }
     'RedHat': {
-      $package_name = 'memcached'
-      $service_name = 'memcached'
-      $config_file  = '/etc/sysconfig/memcached'
-      $config_tmpl  = "$module_name/memcached_sysconfig.erb"
-      $user = 'memcached'
+      $package_name     = 'memcached'
+      $service_name     = 'memcached'
+      $dev_package_name = 'libmemcached-devel'
+      $config_file      = '/etc/sysconfig/memcached'
+      $config_tmpl      = "$module_name/memcached_sysconfig.erb"
+      $user             = 'memcached'
     }
     default: {
       fail("Unsupported platform: ${::osfamily}")


### PR DESCRIPTION
- Works for Debian and RedHat
- Added new parameter to READEME.md
