### PR TITLE
Remove deprecated variable access (introduced in Puppet v3.2.x)

### DIFF
--- a/templates/memcached.conf.erb
+++ b/templates/memcached.conf.erb
@@ -7,7 +7,7 @@
 -P /var/run/memcached.pid
 
 # Log memcached's output
-logfile <%= logfile -%>
+logfile <%= @logfile -%>
 
 <% if @verbosity -%>
 # Verbosity
@@ -16,7 +16,7 @@ logfile <%= logfile -%>
 
 # Use <num> MB memory max to use for object storage.
 <% Puppet::Parser::Functions.function('memcached_max_memory') -%>
--m <%= scope.function_memcached_max_memory([max_memory]) %>
+-m <%= scope.function_memcached_max_memory([@max_memory]) %>
 
 <% if @lock_memory -%>
 # Lock down all paged memory.  There is a limit on how much memory you may lock.
@@ -28,26 +28,20 @@ logfile <%= logfile -%>
 -s <%= unix_socket %>
 <% else -%>
 # IP to listen on
--l <%= listen_ip %>
+-l <%= @listen_ip %>
 
 # TCP port to listen on
--p <%= tcp_port %>
+-p <%= @tcp_port %>
 
 # UDP port to listen on
--U <%= udp_port %>
+-U <%= @udp_port %>
 <% end -%>
 
 # Run daemon as user
--u <%= user %>
+-u <%= @user %>
 
 # Limit the number of simultaneous incoming connections.
--c <%= max_connections %>
+-c <%= @max_connections %>
 
 # Number of threads to use to process incoming requests.
--t <%= processorcount %>
-
-<% if @item_size -%>
-# Override  the  default size of each slab page
--I <%= item_size %>
-<% end -%>
-
+-t <%= @processorcount %>

--- a/templates/memcached_sysconfig.erb
+++ b/templates/memcached_sysconfig.erb
@@ -1,24 +1,24 @@
-PORT="<%= tcp_port %>"
-USER="<%= user %>"
-MAXCONN="<%= max_connections %>"
+PORT="<%= @tcp_port %>"
+USER="<%= @user %>"
+MAXCONN="<%= @max_connections %>"
 <% Puppet::Parser::Functions.function('memcached_max_memory') -%>
-CACHESIZE="<%= scope.function_memcached_max_memory([max_memory]) %>"
+CACHESIZE="<%= scope.function_memcached_max_memory([@max_memory]) %>"
 OPTIONS="<%
 result = []
 if @verbosity
-  result << '-' + verbosity
+  result << '-' + @verbosity
 end
 if @lock_memory
   result << '-k'
 end
 if @listen_ip
-  result << '-l ' + listen_ip
+  result << '-l ' + @listen_ip
 end
 if @udp_port
-  result << '-U ' + udp_port
+  result << '-U ' + @udp_port
 end
 if @item_size
-  result << '-I ' + item_size
+  result << '-I ' + @item_size
 end
-result << '-t ' + processorcount
+result << '-t ' + @processorcount
 -%><%= result.join(' ') -%>"


### PR DESCRIPTION
When running this module under Puppet 3.2.x (in my case 3.2.4), you'll get set of warnings.
Using variables in templates without '@' has been deprecated, and as of 3.2.x

```
Warning: Variable access via 'logfile' is deprecated. Use '@logfile' instead. template[/tmp/vagrant-puppet/modules-0/memcached/templates/memcached.conf.erb]:10
(at /tmp/vagrant-puppet/modules-0/memcached/templates/memcached.conf.erb:10:in `block in result')
Warning: Variable access via 'max_memory' is deprecated. Use '@max_memory' instead. template[/tmp/vagrant-puppet/modules-0/memcached/templates/memcached.conf.erb]:19
(at /tmp/vagrant-puppet/modules-0/memcached/templates/memcached.conf.erb:19:in `block in result')
Warning: Variable access via 'listen_ip' is deprecated. Use '@listen_ip' instead. template[/tmp/vagrant-puppet/modules-0/memcached/templates/memcached.conf.erb]:31
(at /tmp/vagrant-puppet/modules-0/memcached/templates/memcached.conf.erb:31:in `block in result')
Warning: Variable access via 'tcp_port' is deprecated. Use '@tcp_port' instead. template[/tmp/vagrant-puppet/modules-0/memcached/templates/memcached.conf.erb]:34
(at /tmp/vagrant-puppet/modules-0/memcached/templates/memcached.conf.erb:34:in `block in result')
Warning: Variable access via 'udp_port' is deprecated. Use '@udp_port' instead. template[/tmp/vagrant-puppet/modules-0/memcached/templates/memcached.conf.erb]:37
(at /tmp/vagrant-puppet/modules-0/memcached/templates/memcached.conf.erb:37:in `block in result')
Warning: Variable access via 'user' is deprecated. Use '@user' instead. template[/tmp/vagrant-puppet/modules-0/memcached/templates/memcached.conf.erb]:41
(at /tmp/vagrant-puppet/modules-0/memcached/templates/memcached.conf.erb:41:in `block in result')
Warning: Variable access via 'max_connections' is deprecated. Use '@max_connections' instead. template[/tmp/vagrant-puppet/modules-0/memcached/templates/memcached.conf.erb]:44
(at /tmp/vagrant-puppet/modules-0/memcached/templates/memcached.conf.erb:44:in `block in result')
Warning: Variable access via 'processorcount' is deprecated. Use '@processorcount' instead. template[/tmp/vagrant-puppet/modules-0/memcached/templates/memcached.conf.erb]:47
(at /tmp/vagrant-puppet/modules-0/memcached/templates/memcached.conf.erb:47:in `block in result')
```
