### PR TITLE
Add ::operatingsystem case for memcache user

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -23,7 +23,7 @@ class memcached::params {
   }
   case $::operatingsystem {
     'Ubuntu': {
-      $user = 'memcached'
+      $user = 'memcache'
     }
     'Debian': {
       $user = 'nobody'


### PR DESCRIPTION
Ubuntu is now using the memcached user, instead of 'nobody'

Fixes #27
