### PR TITLE
Enforce Linux line endings for *.erb templates.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Enforce Linux line-endings for template files on every operating system.
+*.erb text eol=lf


### PR DESCRIPTION
If the puppet-memcached module is used as a submodule in Windows, the sysconfig template has invalid line-endings. The following error occurs:

[root@hostname sysconfig]# /etc/init.d/memcached start
: command not foundached: line 4:
Starting memcached: chown: invalid user: `memcached\r'
 to switch toe user memcached
                                                           [FAILED]

To fix this issue on every operating system, I would like to enforce Linux line endings for every template file on checkout.
