### PR TITLE
$logfile support for redhat

### DIFF
--- a/templates/memcached_sysconfig.erb
+++ b/templates/memcached_sysconfig.erb
@@ -21,4 +21,7 @@ if @item_size
   result << '-I ' + @item_size
 end
 result << '-t ' + @processorcount
+if @logfile
+  result << '>> ' + @logfile + ' 2>&1'
+end
 -%><%= result.join(' ') -%>"


### PR DESCRIPTION
Ok, tried applying a basic manifest with 
class { memcached: 
  verbosity => 'vvv'
}
And it did write to /var/log/memcached.log
So I consider it tested on my end (slc6).
