### PR TITLE
Fix bug when `package_ensure` was set to `absent`.

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -32,8 +32,10 @@ class memcached (
 
   if $package_ensure == 'absent' {
     $service_ensure = 'stopped'
+    $service_enable = false
   } else {
     $service_ensure = 'running'
+    $service_enable = true
   }
 
   package { $memcached::params::package_name:
@@ -78,7 +80,7 @@ class memcached (
 
   service { $memcached::params::service_name:
     ensure     => $service_ensure,
-    enable     => true,
+    enable     => $service_enable,
     hasrestart => true,
     hasstatus  => $memcached::params::service_hasstatus,
   }

--- a/spec/classes/memcached_spec.rb
+++ b/spec/classes/memcached_spec.rb
@@ -91,6 +91,10 @@ describe 'memcached' do
       :verbosity       => 'vvv',
       :install_dev     => true,
       :processorcount  => 1
+    },
+    {
+      :package_ensure  => 'absent',
+      :install_dev     => true
     }
   ].each do |param_set|
     describe "when #{param_set == {} ? "using default" : "specifying"} class parameters" do
@@ -133,12 +137,21 @@ describe 'memcached' do
             'group'   => 'root'
           )}
 
-          it { should contain_service("memcached").with(
-            'ensure'     => 'running',
-            'enable'     => true,
-            'hasrestart' => true,
-            'hasstatus'  => false
-          )}
+          it { 
+            if param_hash[:package_ensure] == 'absent'
+              should contain_service("memcached").with(
+                'ensure'     => 'stopped',
+                'enable'     => false
+              )
+            else
+              should contain_service("memcached").with(
+                'ensure'     => 'running',
+                'enable'     => true,
+                'hasrestart' => true,
+                'hasstatus'  => false
+              )
+            end
+          }
 
           it 'should compile the template based on the class parameters' do
             content = param_value(
@@ -185,3 +198,5 @@ describe 'memcached' do
     end
   end
 end
+
+# vim: expandtab shiftwidth=2 softtabstop=2


### PR DESCRIPTION
- Service[memcached] `enable` was left to `true` that leads to a non-critical error described in saz/puppet-memcached#42.
