### PR TITLE
Releax the Puppet Enterprise requirement

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -22,7 +22,7 @@
   "requirements": [
     {
       "name": "pe",
-      "version_requirement": "3.2.x"
+      "version_requirement": ">= 3.2.0 < 3.4.0"
     },
     {
       "name": "puppet",


### PR DESCRIPTION
The saz/memcahed module will not be installed for PE versions
other than 3.2.x. This change relaxes the required version to
install for either the 3.2.x or 3.3.x series.

Full compatibility on Puppet Forge will require a new module
release
