### PR TITLE
Added option "auto_removal" this option aim to enable or disable the -M ...

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -18,7 +18,8 @@ class memcached (
   $unix_socket     = undef,
   $install_dev     = false,
   $processorcount  = $::processorcount,
-  $service_restart = true
+  $service_restart = true,
+  $auto_removal    = false
 ) inherits memcached::params {
 
   # validate type and convert string to boolean if necessary

--- a/templates/memcached.conf.erb
+++ b/templates/memcached.conf.erb
@@ -51,3 +51,7 @@ logfile <%= @logfile -%>
 -I <%= @item_size %>
 <% end -%>
 
+<% if @auto_removal -%>
+# Disable automatic removal of items from the cache when out of memory
+-M
+<% end -%>


### PR DESCRIPTION
...option.

According to memcache:

-M  Disable automatic removal of items from the cache when out of memory.
    Additions will not be possible until adequate space is freed up.
