### PR TITLE
Enable SASL support memcached service

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,3 +46,4 @@ If you find this module useful, send some bitcoins to 1Na3YFUmdxKxJLiuRXQYJU2kiN
 * $unix_socket = undef
 * $install_dev = false (TRUE if 'libmemcached-dev' package should be installed)
 * $processorcount = $::processorcount
+* $use_sasl = false (Enable SASL support)

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -17,7 +17,8 @@ class memcached (
   $verbosity       = undef,
   $unix_socket     = undef,
   $install_dev     = false,
-  $processorcount  = $::processorcount
+  $processorcount  = $::processorcount,
+  $use_sasl        = false,
 ) inherits memcached::params {
 
   # validate type and convert string to boolean if necessary

--- a/spec/classes/memcached_spec.rb
+++ b/spec/classes/memcached_spec.rb
@@ -59,7 +59,8 @@ describe 'memcached' do
       :user            => 'nobody',
       :max_connections => '8192',
       :install_dev     => false,
-      :processorcount  => 1
+      :processorcount  => 1,
+      :use_sasl        => false
     }
   end
 
@@ -76,6 +77,7 @@ describe 'memcached' do
       :user            => 'somebdy',
       :max_connections => '8193',
       :verbosity       => 'vvv',
+      :use_sasl        => true,
       :processorcount  => 3
     },
     {
@@ -167,6 +169,9 @@ describe 'memcached' do
             end
             if(param_hash[:lock_memory])
               expected_lines.push("-k")
+            end
+            if(param_hash[:use_sasl])
+              expected_lines.push("-S")
             end
             if(param_hash[:verbosity])
               expected_lines.push("-vvv")

--- a/templates/memcached.conf.erb
+++ b/templates/memcached.conf.erb
@@ -23,6 +23,11 @@ logfile <%= @logfile -%>
 -k
 <% end -%>
 
+<% if @use_sasl -%>
+# Enable SASL support for memcached
+-S
+<% end -%>
+
 <% if @unix_socket -%>
 # UNIX socket path to listen on
 -s <%= @unix_socket %>


### PR DESCRIPTION
Added a parameter use_sasl to be able to start the memcached server with the -S option and enable SASL support.
