### PR TITLE
Replaced references to type() function with is_string() for Puppet 3.7.x...

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -22,7 +22,7 @@ class memcached (
 ) inherits memcached::params {
 
   # validate type and convert string to boolean if necessary
-  if type($manage_firewall) == 'String' {
+  if is_string($manage_firewall) {
     $manage_firewall_bool = str2bool($manage_firewall)
   } else {
     $manage_firewall_bool = $manage_firewall


### PR DESCRIPTION
..., which now reserves the "type" keyword for future use.

https://docs.puppetlabs.com/puppet/3.7/reference/lang_reserved.html#reserved-words
