### PR TITLE
Add support for large memory pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,3 +48,4 @@ If you find this module useful, send some bitcoins to 1Na3YFUmdxKxJLiuRXQYJU2kiN
 * $processorcount = $::processorcount
 * $service_restart = true (restart service after configuration changes, false to prevent restarts)
 * $use_sasl = false (start memcached with SASL support)
+* $large_mem_pages = false (try to use large memory pages)

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -20,7 +20,8 @@ class memcached (
   $processorcount  = $::processorcount,
   $service_restart = true,
   $auto_removal    = false,
-  $use_sasl        = false
+  $use_sasl        = false,
+  $large_mem_pages = false,
 ) inherits memcached::params {
 
   # validate type and convert string to boolean if necessary

--- a/spec/classes/memcached_spec.rb
+++ b/spec/classes/memcached_spec.rb
@@ -60,7 +60,8 @@ describe 'memcached' do
       :max_connections => '8192',
       :install_dev     => false,
       :processorcount  => 1,
-      :use_sasl        => false
+      :use_sasl        => false,
+      :large_mem_pages => false,
     }
   end
 
@@ -78,7 +79,8 @@ describe 'memcached' do
       :max_connections => '8193',
       :verbosity       => 'vvv',
       :processorcount  => 3,
-      :use_sasl        => true
+      :use_sasl        => true,
+      :large_mem_pages => true,
     },
     {
       :package_ensure  => 'present',
@@ -188,6 +190,9 @@ describe 'memcached' do
             end
             if(param_hash[:use_sasl])
               expected_lines.push("-S")
+            end
+            if(param_hash[:large_mem_pages])
+              expected_lines.push("-L")
             end
             (content.split("\n") & expected_lines).should =~ expected_lines
           end

--- a/templates/memcached.conf.erb
+++ b/templates/memcached.conf.erb
@@ -45,6 +45,11 @@ logfile <%= @logfile -%>
 # Run daemon as user
 -u <%= @user %>
 
+<% if @large_mem_pages -%>
+# Try to use large memory pages (if available)
+-L
+<% end -%>
+
 # Limit the number of simultaneous incoming connections.
 -c <%= @max_connections %>
 


### PR DESCRIPTION
Add support for large memory pages, enabled with `-L` in the configuration file.
