### PR TITLE
Convert @processorcount to string

### DIFF
--- a/templates/memcached_sysconfig.erb
+++ b/templates/memcached_sysconfig.erb
@@ -15,7 +15,7 @@ end
 if @item_size
   result << '-I ' + @item_size.to_s
 end
-result << '-t ' + @processorcount
+result << '-t ' + @processorcount.to_s
 if @logfile
   result << '>> ' + @logfile + ' 2>&1'
 end


### PR DESCRIPTION
I'm getting this error when `stringify_facts = false`:

```
Error: Could not retrieve catalog from remote server: Error 400 on SERVER: Failed to parse template memcached/memcached_sysconfig.erb:
  Filepath: /etc/puppet/environments/production/modules/memcached/templates/memcached_sysconfig.erb
  Line: 18
  Detail: can't convert Fixnum into String
 at /etc/puppet/environments/production/modules/memcached/manifests/init.pp:78 on node v-wh1.vagrant
```

---
btw, thanks for all of your great work @saz !
