### PR TITLE
add support for logging to syslog.

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -2,9 +2,15 @@
 #
 # Manage memcached
 #
+# == Parameters
+# [* syslog *]
+# Boolean.
+# If true will pipe output to /bin/logger, sends to syslog.
+#
 class memcached (
   $package_ensure  = 'present',
   $logfile         = '/var/log/memcached.log',
+  $syslog          = false,
   $pidfile         = '/var/run/memcached.pid',
   $manage_firewall = false,
   $max_memory      = false,
@@ -33,6 +39,14 @@ class memcached (
   }
   validate_bool($manage_firewall_bool)
   validate_bool($service_restart)
+
+  validate_bool($syslog)
+
+  # Logging to syslog and file are mutually exclusive
+  # Fail if both options are defined
+  if $syslog and $logfile {
+    fail 'Define either syslog or logfile as logging destinations but not both.'
+  }
 
   if $package_ensure == 'absent' {
     $service_ensure = 'stopped'

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -44,7 +44,7 @@ class memcached (
 
   # Logging to syslog and file are mutually exclusive
   # Fail if both options are defined
-  if $syslog and $logfile {
+  if $syslog and str2bool("$logfile") {
     fail 'Define either syslog or logfile as logging destinations but not both.'
   }
 

--- a/templates/memcached_sysconfig.erb
+++ b/templates/memcached_sysconfig.erb
@@ -16,7 +16,12 @@ if @item_size
   result << '-I ' + @item_size.to_s
 end
 result << '-t ' + @processorcount
-if @logfile
+
+# log to syslog via logger
+if @syslog && @logfile.empty?
+	result << '2>&1 |/bin/logger &'
+# log to log file
+elsif !@logfile.empty? && !@syslog
   result << '>> ' + @logfile + ' 2>&1'
 end
 -%>


### PR DESCRIPTION
Added boolean parameter syslog. If syslog is true and logfile is empty then
configure sysconfig options to pipe output to /bin/logger.

syslog and logfile are mutually exclusive options. they cannot be used together.