### PR TITLE
force processors value to string

### DIFF
--- a/templates/memcached_sysconfig.erb
+++ b/templates/memcached_sysconfig.erb
@@ -15,7 +15,7 @@ end
 if @item_size
   result << '-I ' + @item_size.to_s
 end
-result << '-t ' + @processorcount
+result << '-t ' + @processorcount.to_s
 if @logfile
   result << '>> ' + @logfile + ' 2>&1'
 end


### PR DESCRIPTION
Was getting a run failure when upgrading to puppet enterprise 3.7.2

Error: Could not retrieve catalog from remote server: Error 400 on SERVER: Failed to parse template memcached/memcached_sysconfig.erb:
  Filepath: org/jruby/RubyString.java
  Line: 1159
  Detail: can't convert Fixnum into String
 at /etc/puppetlabs/puppet/environments/production/modules/memcached/manifests/init.pp:78 on node foo
Warning: Not using cache on failed catalog
Error: Could not retrieve catalog; skipping run

forcing the processors value to a string seems to have made things happy