### PR TITLE
Feature: parameterized lock file allocation

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -6,6 +6,7 @@ class memcached (
   $package_ensure  = 'present',
   $logfile         = $::memcached::params::logfile,
   $pidfile         = '/var/run/memcached.pid',
+  $lockfile        = '/var/lock/subsys/memcached',
   $manage_firewall = false,
   $max_memory      = false,
   $item_size       = false,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -79,8 +79,8 @@ class memcached (
 
   if ( $memcached::params::config_file ) {
     file { $memcached::params::config_file:
-      owner   => 'root',
-      group   => 'root',
+      owner   => 'memcached',
+      group   => 'memcached',
       mode    => '0644',
       content => template($memcached::params::config_tmpl),
       require => Package[$memcached::params::package_name],

--- a/spec/classes/memcached_spec.rb
+++ b/spec/classes/memcached_spec.rb
@@ -143,8 +143,8 @@ describe 'memcached' do
           }
 
           it { should contain_file("/etc/memcached.conf").with(
-            'owner'   => 'root',
-            'group'   => 'root'
+            'owner'   => 'memcached',
+            'group'   => 'memcached'
           )}
 
           it { 

--- a/templates/memcached_sysconfig.erb
+++ b/templates/memcached_sysconfig.erb
@@ -50,3 +50,4 @@ MEMCACHED_USER="<%= @user %>"
 #
 MEMCACHED_GROUP="<%= @user %>"
 <%- end -%>
+LOCKFILE="<%= @lockfile %>"


### PR DESCRIPTION
By default the lockfile will be written in /var/lock/subsys/memcached, but if you want to change this path for example if you want to start stop the process as memcached user you could override the LOCKFILE parameter in the sysconfig file.