### PR TITLE
feature: Add possibilty to configure no listen_ip.

### DIFF
--- a/spec/classes/memcached_spec.rb
+++ b/spec/classes/memcached_spec.rb
@@ -97,6 +97,9 @@ describe 'memcached' do
       :processorcount  => 1
     },
     {
+      :listen_ip       => '',
+    },
+    {
       :pidfile         => false,
     },
     {
@@ -172,7 +175,6 @@ describe 'memcached' do
             )
             expected_lines = [
               "logfile #{param_hash[:logfile]}",
-              "-l #{param_hash[:listen_ip]}",
               "-p #{param_hash[:tcp_port]}",
               "-U #{param_hash[:udp_port]}",
               "-u #{param_hash[:user]}",
@@ -187,6 +189,9 @@ describe 'memcached' do
               end
             else
               expected_lines.push("-m 950")
+            end
+            if(param_hash[:listen_ip] != '')
+              expected_lines.push("-l #{param_hash[:listen_ip]}")
             end
             if(param_hash[:lock_memory])
               expected_lines.push("-k")

--- a/templates/memcached.conf.erb
+++ b/templates/memcached.conf.erb
@@ -34,8 +34,11 @@ logfile <%= @logfile -%>
 # UNIX socket path to listen on
 -s <%= @unix_socket %>
 <% else -%>
+
+<% if @listen_ip != '' -%>
 # IP to listen on
 -l <%= @listen_ip %>
+<% end -%>
 
 # TCP port to listen on
 -p <%= @tcp_port %>


### PR DESCRIPTION
There is no need to define the listen_ip. If no listen IP is defined, memchached will bind to 0.0.0.0 and :: 