### PR TITLE
Solaris support for SMF management of memcached

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -6,5 +6,8 @@ fixtures:
     'stdlib':
       repo: 'git://github.com/puppetlabs/puppetlabs-stdlib.git'
       ref: '3.2.0'
+    'svcprop':
+      repo: 'https://github.com/bolthole/puppet-svcprop.git'
+      ref: 'e60b1abddb8b8861408e0eccf8c989737d112a60'
   symlinks:
     memcached: "#{source_dir}"

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -31,7 +31,10 @@ class memcached (
   $use_sasl        = false,
   $use_registry    = $::memcached::params::use_registry,
   $registry_key    = 'HKLM\System\CurrentControlSet\services\memcached\ImagePath',
-  $large_mem_pages = false
+  $large_mem_pages = false,
+  $use_svcprop     = $::memcached::params::use_svcprop,
+  $svcprop_fmri    = 'memcached:default',
+  $svcprop_key     = 'memcached/options'
 ) inherits memcached::params {
 
   # validate type and convert string to boolean if necessary
@@ -118,6 +121,15 @@ class memcached (
       type   => 'string',
       data   => template($memcached::params::config_tmpl),
       notify => $service_notify_real,
+    }
+  }
+
+  if $use_svcprop {
+    svcprop { $svcprop_key:
+      fmri     => $svcprop_fmri,
+      property => $svcprop_key,
+      value    => template($memcached::params::config_tmpl),
+      notify   => $service_notify_real
     }
   }
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -13,6 +13,7 @@ class memcached::params {
       $user              = 'nobody'
       $logfile           = '/var/log/memcached.log'
       $use_registry      = false
+      $use_svcprop       = false
     }
     /RedHat|Suse/: {
       $package_name      = 'memcached'
@@ -25,6 +26,7 @@ class memcached::params {
       $user              = 'memcached'
       $logfile           = '/var/log/memcached.log'
       $use_registry      = false
+      $use_svcprop       = false
     }
     /windows/: {
       $package_name      = 'memcached'
@@ -37,6 +39,20 @@ class memcached::params {
       $user              = 'BUILTIN\Administrators'
       $logfile           = undef
       $use_registry      = true
+      $use_svcprop       = false
+    }
+    'Solaris': {
+      $package_name      = 'memcached'
+      $package_provider  = undef
+      $service_name      = 'memcached'
+      $service_hasstatus = false
+      $dev_package_name  = undef
+      $config_file       = undef
+      $config_tmpl       = "${module_name}/memcached_svcprop.erb"
+      $user              = 'nobody'
+      $logfile           = '/var/log/memcached.log'
+      $use_registry      = false
+      $use_svcprop       = true
     }
     default: {
       case $::operatingsystem {
@@ -51,6 +67,7 @@ class memcached::params {
           $user              = 'memcached'
           $logfile           = '/var/log/memcached.log'
           $use_registry      = false
+          $use_svcprop       = false
         }
         default: {
           fail("Unsupported platform: ${::osfamily}/${::operatingsystem}")

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -46,7 +46,7 @@ class memcached::params {
       $package_provider  = undef
       $service_name      = 'memcached'
       $service_hasstatus = false
-      $dev_package_name  = undef
+      $dev_package_name  = 'libmemcached'
       $config_file       = undef
       $config_tmpl       = "${module_name}/memcached_svcprop.erb"
       $user              = 'nobody'

--- a/spec/classes/memcached_spec.rb
+++ b/spec/classes/memcached_spec.rb
@@ -226,6 +226,51 @@ describe 'memcached' do
       end
     end
   end
+
+  context 'On Solaris' do
+    let :facts do
+      {
+        :osfamily => 'Solaris',
+        :memorysize => '1000 MB',
+        :processorcount => '1',
+      }
+    end
+
+    describe 'when using default class parameters' do
+      let :param_hash do
+        default_params
+      end
+
+      let :params do
+        {}
+      end
+
+      it { should contain_class("memcached::params") }
+
+      it { should contain_package("memcached").with_ensure('present') }
+
+      it { should_not contain_firewall('100_tcp_11211_for_memcached') }
+      it { should_not contain_firewall('100_udp_11211_for_memcached') }
+
+      it {
+        should contain_service("memcached").with(
+           'ensure'     => 'running',
+           'enable'     => true,
+           'hasrestart' => true,
+           'hasstatus'  => false
+        )
+      }
+
+      it {
+        should contain_svcprop("memcached/options").with(
+          'fmri'     => 'memcached:default',
+          'property' => 'memcached/options',
+          'value'    => '"-m" "950" "-l" "0.0.0.0" "-p" "11211" "-U" "11211" "-u" "nobody" "-c" "8192" "-t" "1"',
+          'notify'   => 'Service[memcached]'
+        )
+      }
+    end
+  end
 end
 
 # vim: expandtab shiftwidth=2 softtabstop=2

--- a/templates/memcached_svcprop.erb
+++ b/templates/memcached_svcprop.erb
@@ -1,0 +1,66 @@
+<%-
+result = []
+
+if @verbosity
+  # Verbosity
+  result << '"-' + @verbosity.to_s + '"'
+end
+
+# Use <num> MB memory max to use for object storage.
+Puppet::Parser::Functions.function('memcached_max_memory')
+result << '"-m" "' + scope.function_memcached_max_memory([@max_memory]).to_s + '"'
+
+if @lock_memory
+  # Lock down all paged memory.  There is a limit on how much memory you may lock.
+  result << '"-k"'
+end
+
+if @use_sasl
+  # Start with SASL support
+  result << '"-S"'
+end
+
+if @unix_socket
+  # UNIX socket path to listen on
+  result << '"-s" "' + @unix_socket + '"'
+else
+  if @listen_ip
+    # IP to listen on
+    result << '"-l" "' + @listen_ip + '"'
+  end
+
+  # TCP port to listen on
+  if @tcp_port
+    result << '"-p" "' + @tcp_port.to_s + '"'
+  end
+
+  # UDP port to listen on
+  if @udp_port
+    result << '"-U" "' + @udp_port.to_s + '"'
+  end
+end
+
+# Run daemon as user
+result << '"-u" "' + @user + '"'
+
+if @large_mem_pages
+  # Try to use large memory pages (if available)
+  result << '"-L"'
+end
+
+# Limit the number of simultaneous incoming connections.
+result << '"-c" "' + @max_connections.to_s + '"'
+
+# Number of threads to use to process incoming requests.
+result << '"-t" "' + @processorcount.to_s + '"'
+
+if @item_size
+  # Override  the  default size of each slab page
+  result << '"-I" "' + @item_size.to_s + '"'
+end
+
+if @auto_removal
+  # Disable automatic removal of items from the cache when out of memory
+  result << '"-M"'
+end -%>
+<%= result.join(' ') %>


### PR DESCRIPTION
This adds new OS support for Solaris 11.2, in a similar vein to the Windows support (i.e. it doesn't use a config file, but instead uses `svcprop` to manage configuration of the SMF service). Some config variables, notably logfile, are unsupported; others such as pidfile management are intentionally excluded as SMF manages that.