### PR TITLE
Ulimit Management & init script logging

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -33,7 +33,7 @@
     }
   ],
   "name": "saz-memcached",
-  "version": "2.8.1.2",
+  "version": "2.8.1.3",
   "author": "saz",
   "summary": "Manage memcached via Puppet",
   "license": "Apache License, Version 2.0",

--- a/metadata.json
+++ b/metadata.json
@@ -33,7 +33,7 @@
     }
   ],
   "name": "saz-memcached",
-  "version": "2.8.1.3",
+  "version": "2.8.1.4",
   "author": "saz",
   "summary": "Manage memcached via Puppet",
   "license": "Apache License, Version 2.0",

--- a/metadata.json
+++ b/metadata.json
@@ -33,7 +33,7 @@
     }
   ],
   "name": "saz-memcached",
-  "version": "2.8.1.4",
+  "version": "2.8.1.5",
   "author": "saz",
   "summary": "Manage memcached via Puppet",
   "license": "Apache License, Version 2.0",

--- a/metadata.json
+++ b/metadata.json
@@ -33,7 +33,7 @@
     }
   ],
   "name": "saz-memcached",
-  "version": "2.8.1",
+  "version": "2.8.1.1",
   "author": "saz",
   "summary": "Manage memcached via Puppet",
   "license": "Apache License, Version 2.0",

--- a/metadata.json
+++ b/metadata.json
@@ -33,7 +33,7 @@
     }
   ],
   "name": "saz-memcached",
-  "version": "2.8.1.1",
+  "version": "2.8.1.2",
   "author": "saz",
   "summary": "Manage memcached via Puppet",
   "license": "Apache License, Version 2.0",

--- a/templates/memcached_sysconfig.erb
+++ b/templates/memcached_sysconfig.erb
@@ -55,3 +55,7 @@ MEMCACHED_USER="<%= @user %>"
 #
 MEMCACHED_GROUP="<%= @user %>"
 <%- end -%>
+<%- if @lock_memory -%>
+if [[ $(whoami) != "root" ]]; then echo "Must be root to set ulimit higher!"; exit 1; fi
+ulimit -l <%= scope.function_memcached_max_memory([@max_memory]) * 1024 %>
+<%- end -%>

--- a/templates/memcached_sysconfig.erb
+++ b/templates/memcached_sysconfig.erb
@@ -57,5 +57,5 @@ MEMCACHED_GROUP="<%= @user %>"
 <%- end -%>
 <%- if @lock_memory -%>
 if [[ $(whoami) != "root" ]]; then echo "Must be root to set ulimit higher!"; exit 1; fi
-ulimit -l <%= scope.function_memcached_max_memory([@max_memory]) * 1024 %>
+ulimit -l <%= (scope.function_memcached_max_memory([@max_memory]) + 105) * 1024 %>
 <%- end -%>

--- a/templates/memcached_sysconfig.erb
+++ b/templates/memcached_sysconfig.erb
@@ -59,3 +59,9 @@ MEMCACHED_GROUP="<%= @user %>"
 if [[ $(whoami) != "root" ]]; then echo "Must be root to set ulimit higher!"; exit 1; fi
 ulimit -l <%= (scope.function_memcached_max_memory([@max_memory]) + 105) * 1024 %>
 <%- end -%>
+<%- if @syslog -%>
+logger "Running: service memcached $1"
+<%- end -%>
+<%- if !@logfile.empty? -%>
+echo "$(date +"%Y-%m-%d %H:%M:%S") Running: service memcached $1" >> "<%= @logfile %>"
+<%- end -%>

--- a/templates/memcached_sysconfig.erb
+++ b/templates/memcached_sysconfig.erb
@@ -56,8 +56,11 @@ MEMCACHED_USER="<%= @user %>"
 MEMCACHED_GROUP="<%= @user %>"
 <%- end -%>
 <%- if @lock_memory -%>
-if [[ $(whoami) != "root" ]]; then echo "Must be root to set ulimit higher!"; exit 1; fi
-ulimit -l <%= (scope.function_memcached_max_memory([@max_memory]) + 105) * 1024 %>
+if [[ $(whoami) != "root" ]]; then echo "Must be root to manage memcached!"; exit 1; fi
+## ulimit = base process size + per thread size + cache space
+## ulimit = 92000 + (76000 * threads) + (cachesize * 1024)
+## ulimit = 92000 + (76000 * <%= @processorcount.to_s %>) + (<%= scope.function_memcached_max_memory([@max_memory]) %> * 1024)
+ulimit -l <%= 92000 + (76000 * @processorcount.to_s) + (scope.function_memcached_max_memory([@max_memory]) * 1024) %>
 <%- end -%>
 <%- if @syslog -%>
 logger "Running: service memcached $1"

--- a/templates/memcached_sysconfig.erb
+++ b/templates/memcached_sysconfig.erb
@@ -59,8 +59,8 @@ MEMCACHED_GROUP="<%= @user %>"
 if [[ $(whoami) != "root" ]]; then echo "Must be root to manage memcached!"; exit 1; fi
 ## ulimit = base process size + per thread size + cache space
 ## ulimit = 92000 + (76000 * threads) + (cachesize * 1024)
-## ulimit = 92000 + (76000 * <%= @processorcount.to_s %>) + (<%= scope.function_memcached_max_memory([@max_memory]) %> * 1024)
-ulimit -l <%= 92000 + (76000 * @processorcount.to_s) + (scope.function_memcached_max_memory([@max_memory]) * 1024) %>
+## ulimit = 92000 + (76000 * <%= @processorcount.to_i %>) + (<%= scope.function_memcached_max_memory([@max_memory]) %> * 1024)
+ulimit -l <%= 92000 + (76000 * @processorcount.to_i) + (scope.function_memcached_max_memory([@max_memory]) * 1024) %>
 <%- end -%>
 <%- if @syslog -%>
 logger "Running: service memcached $1"


### PR DESCRIPTION
Manage the ulimit based off the cache size when lock memory is set.
Add log entries when the init script is called
