### PR TITLE
fix puppetlabs-firewall port parameter deprecation warning

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -74,13 +74,13 @@ class memcached (
 
   if $manage_firewall_bool == true {
     firewall { "100_tcp_${tcp_port}_for_memcached":
-      port   => $tcp_port,
+      dport  => $tcp_port,
       proto  => 'tcp',
       action => 'accept',
     }
 
     firewall { "100_udp_${udp_port}_for_memcached":
-      port   => $udp_port,
+      dport  => $udp_port,
       proto  => 'udp',
       action => 'accept',
     }


### PR DESCRIPTION
2015-08-25 - Supported Release 1.7.1
Summary
This is a bugfix release to deprecate the port parameter. Using the unspecific 'port' parameter can lead to firewall rules that are unexpectedly too lax. It is recommended to always use the specific dport and sport parameters to avoid this ambiguity.