### PR TITLE
Added support for unix_socket in the sysconfig template

### DIFF
--- a/templates/memcached_sysconfig.erb
+++ b/templates/memcached_sysconfig.erb
@@ -12,6 +12,9 @@ end
 if @udp_port
   result << '-U ' + @udp_port.to_s
 end
+if @unix_socket
+  result << '-s ' + @unix_socket.to_s + '-a 0755 '
+end
 if @item_size
   result << '-I ' + @item_size.to_s
 end


### PR DESCRIPTION
I noticed that if unix_socket is specified in the puppet config, the module didn't add the parameter to the sysconfig file for Redhat/Centos servers.
Changing this template file will add it. I also added the default permissions to be 0755 for the socket because otherwise other applications can not actually talk to the socket. It would be better to have a socket permissions parameter instead of hard coding it.