### PR TITLE
Add FreeBSD support; remove group for config file: by default, puppet…

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -52,6 +52,15 @@ class memcached (
     fail 'Define either syslog or logfile as logging destinations but not both.'
   }
 
+  # Make sure logfile exist with correct ownership
+  if $logfile {
+         file { "memcached_${logfile}":
+                name    => $logfile,
+                owner   => "$user",
+                ensure  => file,
+        }
+  }
+
   if $package_ensure == 'absent' {
     $service_ensure = 'stopped'
     $service_enable = false
@@ -95,7 +104,6 @@ class memcached (
   if ( $memcached::params::config_file ) {
     file { $memcached::params::config_file:
       owner   => 'root',
-      group   => 'root',
       mode    => '0644',
       content => template($memcached::params::config_tmpl),
       require => Package[$memcached::params::package_name],

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -54,11 +54,11 @@ class memcached (
 
   # Make sure logfile exist with correct ownership
   if $logfile {
-         file { "memcached_${logfile}":
-                name    => $logfile,
-                owner   => "$user",
-                ensure  => file,
-        }
+    file { "memcached_${logfile}":
+      name    => $logfile,
+      owner   => "$user",
+      ensure  => file,
+    }
   }
 
   if $package_ensure == 'absent' {

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -26,6 +26,18 @@ class memcached::params {
       $logfile           = '/var/log/memcached.log'
       $use_registry      = false
     }
+    'FreeBSD': {
+      $package_name      = 'memcached'
+      $package_provider  = undef
+      $service_name      = 'memcached'
+      $service_hasstatus = true
+      $dev_package_name  = undef
+      $config_file       = '/etc/rc.conf.d/memcached'
+      $config_tmpl       = "${module_name}/memcached_freebsd_rcconf.erb"
+      $user              = 'nobody'
+      $logfile           = '/var/log/memcached.log'
+      $use_registry      = false
+    }
     /windows/: {
       $package_name      = 'memcached'
       $package_provider  = 'chocolatey'

--- a/templates/memcached_freebsd_rcconf.erb
+++ b/templates/memcached_freebsd_rcconf.erb
@@ -18,9 +18,9 @@ end
 if @item_size
   result << '-I ' + @item_size.to_s
 end
-result << '-t ' + @processorcount
+result << '-t ' + @processorcount.to_s
 if @max_connections 
-  result << '-c ' + @max_connections
+  result << '-c ' + @max_connections.to_s
 end
 if @logfile
   result << '>> ' + @logfile + ' 2>&1'

--- a/templates/memcached_freebsd_rcconf.erb
+++ b/templates/memcached_freebsd_rcconf.erb
@@ -1,0 +1,30 @@
+<%-
+result = []
+if @verbosity
+  result << '-' + @verbosity.to_s
+end
+if @lock_memory
+  result << '-k'
+end
+if @listen_ip
+  result << '-l ' + @listen_ip
+end
+if @tcp_port
+  result << '-p ' + @tcp_port.to_s
+end
+if @udp_port
+  result << '-U ' + @udp_port.to_s
+end
+if @item_size
+  result << '-I ' + @item_size.to_s
+end
+result << '-t ' + @processorcount
+if @max_connections 
+  result << '-c ' + @max_connections
+end
+if @logfile
+  result << '>> ' + @logfile + ' 2>&1'
+end -%>
+memcached_enable="YES"
+memcached_flags="-d -u nobody -P /var/run/memcached/memcached.pid <%= result.join(' ') %>"
+

--- a/templates/memcached_freebsd_rcconf.erb
+++ b/templates/memcached_freebsd_rcconf.erb
@@ -24,6 +24,9 @@ if @max_connections
 end
 if @logfile
   result << '>> ' + @logfile + ' 2>&1'
+end
+if @unix_socket
+  result << '-s ' + @unix_socket
 end -%>
 memcached_enable="YES"
 memcached_flags="-d -u nobody -P /var/run/memcached/memcached.pid <%= result.join(' ') %>"


### PR DESCRIPTION
… create file owned by superuser. Some OS or distros have root group name as "wheel", e.g: RHEL, Oracle, FreeBSD. Puppet inherits correct group name for target distros. On the other hand, it is possible to make the variable configurable, for example, introduce something like $config_group_name
