### PR TITLE
allow custom runtime params on freebsd

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -60,8 +60,8 @@ class memcached::params {
       $service_name      = 'memcached'
       $service_hasstatus = false
       $dev_package_name  = 'libmemcached'
-      $config_file       = undef
-      $config_tmpl       = "${module_name}/memcached_svcprop.erb"
+      $config_file       = '/etc/rc.conf.d/memcached'
+      $config_tmpl       = "${module_name}/memcached_freebsd_rcconf.erb"
       $user              = 'nobody'
       $logfile           = '/var/log/memcached.log'
       $use_registry      = false

--- a/templates/memcached_freebsd_rcconf.erb
+++ b/templates/memcached_freebsd_rcconf.erb
@@ -1,0 +1,52 @@
+### MANAGED BY PUPPET
+### DO NOT EDIT
+
+<%-
+enabled = "YES"
+if !@service_manage
+  enabled = "NO"
+end
+
+flags = []
+# required flags
+flags << "-d -u #{@user} -P #{@pidfile} -t #{@processorcount}"
+
+# optional flags
+if @item_size
+  flags << "-I #{@item_size.to_s}"
+end
+
+if @listen_ip
+  flags << "-l #{@listen_ip}"
+end
+
+if @lock_memory
+  flags << "-k"
+end
+
+if @max_connections
+  flags << "-c #{@max_connections}"
+end
+
+#TODO: wtf do we do with this?
+#if @logfile
+#end
+
+if @tcp_port
+  flags << "-p #{@tcp_port.to_s}"
+end
+
+if @udp_port
+  flags << "-U #{@udp_port.to_s}"
+end
+
+if @unix_socket
+  flags << "-s #{@unix_socket}"
+end
+
+if @verbosity
+  flags << "-#{@verbosity.to_s}"
+end
+-%>
+memcached_enable="<%= enabled %>"
+memcached_flags="<%= flags.join(" ") %>"


### PR DESCRIPTION
this is a continuation of #79 and incorporates some of the changes from #73.

@olevole was there really not a better way to incorporate `$logfile` than to redirect to it?  that seems really ugly.