### PR TITLE
Make sysconfig configuration work with undef values for logfile

### DIFF
--- a/templates/memcached_sysconfig.erb
+++ b/templates/memcached_sysconfig.erb
@@ -30,10 +30,10 @@ end
 result << '-t ' + @processorcount.to_s
 
 # log to syslog via logger
-if @syslog && @logfile.empty?
+if @syslog && !@logfile
 	result << '2>&1 |/bin/logger &'
 # log to log file
-elsif !@logfile.empty? && !@syslog
+elsif @logfile && !@syslog
   result << '>> ' + @logfile + ' 2>&1'
 end
 -%>


### PR DESCRIPTION
With setting of data types for parameters, the logfile is now of type
Optional[Stdlib::Absolutepath]. This means that we can no longer set the
logfile to be an empty string, and thus we memcached configuration
doesn't do a relevant check for it.

Instead, we now handle undef, which is a valid value with the Optional
type.