### PR TITLE
Fix .rubocop.yml issues

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -163,6 +163,9 @@ Style/ClassAndModuleChildren:
 Style/ClassCheck:
   Enabled: true
 
+Naming/HeredocDelimiterNaming:
+  Enabled: false
+
 # Class length is not necessarily an indicator of code quality
 Metrics/ClassLength:
   Enabled: false

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -521,3 +521,6 @@ RSpec/ExampleLength:
 
 RSpec/NestedGroups:
   Max: 4
+
+RSpec/MultipleExpectations:
+  Enabled: False

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -412,7 +412,7 @@ Style/NumericLiterals:
 Style/OneLineConditional:
   Enabled: true
 
-Style/OpMethod:
+Naming/BinaryOperatorParameterName:
   Enabled: true
 
 Style/ParenthesesAroundCondition:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,6 +1,6 @@
 require: rubocop-rspec
 AllCops:
-  TargetRubyVersion: 1.9
+  TargetRubyVersion: 2.1
   Include:
     - ./**/*.rb
   Exclude:
@@ -516,5 +516,5 @@ RSpec/DescribeClass:
 RSpec/ExampleLength:
   Enabled: False
 
-RSpec/NestedGroups:                                                                                                                                                                                              
+RSpec/NestedGroups:
   Max: 4

--- a/lib/puppet/parser/functions/memcached_max_memory.rb
+++ b/lib/puppet/parser/functions/memcached_max_memory.rb
@@ -1,7 +1,7 @@
 module Puppet::Parser::Functions
-  newfunction(:memcached_max_memory, :type => :rvalue, :doc => <<-EOS
+  newfunction(:memcached_max_memory, :type => :rvalue, :doc => <<-ENDHEREDOC
     Calculate max_memory size from fact 'memsize' and passed argument.
-    EOS
+    ENDHEREDOC
   ) do |arguments|
 
     if arguments.size != 1

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -1,5 +1,24 @@
 require 'spec_helper'
 describe 'memcached' do
+
+  let :default_params do
+    {
+      package_ensure: 'present',
+      logfile: '/var/log/memcached.log',
+      lock_memory: false,
+      listen_ip: '127.0.0.1',
+      tcp_port: 11211,
+      udp_port: 11211,
+      user: 'nobody',
+      max_connections: 8192,
+      install_dev: false,
+      processorcount: 1,
+      use_sasl: false,
+      large_mem_pages: false,
+      pidfile: '/var/run/memcached.pid'
+    }
+  end
+
   describe 'with manage_firewall parameter' do
     %w[Debian RedHat].each do |osfam|
       context "on osfamily #{osfam}" do
@@ -38,24 +57,6 @@ describe 'memcached' do
         end
       end
     end
-  end
-
-  let :default_params do
-    {
-      package_ensure: 'present',
-      logfile: '/var/log/memcached.log',
-      lock_memory: false,
-      listen_ip: '127.0.0.1',
-      tcp_port: 11211,
-      udp_port: 11211,
-      user: 'nobody',
-      max_connections: 8192,
-      install_dev: false,
-      processorcount: 1,
-      use_sasl: false,
-      large_mem_pages: false,
-      pidfile: '/var/run/memcached.pid'
-    }
   end
 
   [{},

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -1,6 +1,5 @@
 require 'spec_helper'
 describe 'memcached' do
-
   let :default_params do
     {
       package_ensure: 'present',

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,7 +2,7 @@ require 'puppetlabs_spec_helper/module_spec_helper'
 
 RSpec.configure do |config|
   config.hiera_config = 'spec/fixtures/hiera/hiera.yaml'
-  config.before :each do
+  config.before do
     # Ensure that we don't accidentally cache facts and environment between
     # test cases.  This requires each example group to explicitly load the
     # facts being exercised with something like


### PR DESCRIPTION
One cop had been renamed and was breaking in CI. And it was using an unsupported target ruby version.