### PR TITLE
Remove checking for $listen_ip

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -19,7 +19,7 @@ class memcached (
   Optional[Variant[Integer, String]] $min_item_size   = undef,
   Boolean $factor                                     = false,
   Boolean $lock_memory                                = false,
-  Optional[Stdlib::Compat::Ip_address] $listen_ip     = '127.0.0.1',
+  $listen_ip                                          = '127.0.0.1',
   Integer $tcp_port                                   = 11211,
   Integer $udp_port                                   = 11211,
   String $user                                        = $::memcached::params::user,


### PR DESCRIPTION
Stdlib::compat::Ip_address is only checking for a single IP Address, whereas memcached can actually listen for an array of IP Addresses that is comma separated. Thus the memcached module is artificially limiting a valid configuration option in memcached.
I don't have a better idea for how to validate, but this Pull Request at least removes the problem.