### PR TITLE
.rubocop.yml : update TrailingCommainLiteral

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -313,9 +313,12 @@ Style/StringLiterals:
 Style/TrailingCommaInArguments:
   Enabled: true
 
-Style/TrailingCommaInLiteral:
+Style/TrailingCommaInArrayLiteral:
   Enabled: true
 
+Style/TrailingCommaInHashLiteral:
+  Enabled: true
+  
 Style/GlobalVars:
   Enabled: true
 


### PR DESCRIPTION
clear this error: 
    Error: The `Style/TrailingCommaInLiteral` cop no longer exists. Please use `Style/TrailingCommaInArrayLiteral` and/or 
    `Style/TrailingCommaInHashLiteral` instead.