### PR TITLE
Allow an array of IP addresses in addition to a single IP address

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -57,6 +57,9 @@ class memcached (
     $service_enable = true
   }
 
+  # Handle if $listen_ip is an array
+  $real_listen_ip = [ $listen_ip ]
+
   package { $memcached::params::package_name:
     ensure   => $package_ensure,
     provider => $memcached::params::package_provider,

--- a/templates/memcached.conf.erb
+++ b/templates/memcached.conf.erb
@@ -37,9 +37,9 @@ logfile <%= @logfile -%>
 -a <%= @unix_socket_mask %>
 <% else -%>
 
-<% if @listen_ip -%>
+<% if @real_listen_ip -%>
 # IP to listen on
--l <%= @listen_ip %>
+-l <%= @real_listen_ip.join(',') %>
 <% end -%>
 
 # TCP port to listen on

--- a/templates/memcached_freebsd_rcconf.erb
+++ b/templates/memcached_freebsd_rcconf.erb
@@ -16,8 +16,8 @@ if @item_size
   flags << "-I #{@item_size.to_s}"
 end
 
-if @listen_ip
-  flags << "-l #{@listen_ip}"
+if @real_listen_ip
+  flags << "-l #{@real_listen_ip.join(',')}"
 end
 
 if @lock_memory

--- a/templates/memcached_svcprop.erb
+++ b/templates/memcached_svcprop.erb
@@ -26,9 +26,9 @@ if @unix_socket
   # UNIX socket access mask
   result << '"-a" "' + @unix_socket_mask + '"'
 else
-  if @listen_ip
+  if @real_listen_ip
     # IP to listen on
-    result << '"-l" "' + @listen_ip + '"'
+    result << '"-l" "' + @real_listen_ip.join(',') + '"'
   end
 
   # TCP port to listen on

--- a/templates/memcached_sysconfig.erb
+++ b/templates/memcached_sysconfig.erb
@@ -6,8 +6,8 @@ end
 if @lock_memory
   result << '-k'
 end
-if @listen_ip
-  result << '-l ' + @listen_ip
+if @real_listen_ip
+  result << '-l ' + @real_listen_ip.join(',')
 end
 if @udp_port
   result << '-U ' + @udp_port.to_s
@@ -26,7 +26,7 @@ if @factor
 end
 if @extended_opts
   result << '-o ' + @extended_opts.join(',')
-end 
+end
 if @disable_cachedump
   result << '-X'
 end

--- a/templates/memcached_windows.erb
+++ b/templates/memcached_windows.erb
@@ -6,8 +6,8 @@ end
 if @lock_memory
   result << '-k'
 end
-if @listen_ip
-  result << '-l ' + @listen_ip
+if @real_listen_ip
+  result << '-l ' + @real_listen_ip.join(',')
 end
 if @tcp_port
   result << '-p ' + @tcp_port.to_s
@@ -25,7 +25,7 @@ if @factor
   result << '-f ' + @factor.to_s
 end
 result << '-t ' + @processorcount
-if @max_connections 
+if @max_connections
   result << '-c ' + @max_connections
 end
 if @extended_opts


### PR DESCRIPTION
In its current state, using an array of IP addresses just dumps the string `-l [ ipaddr1, ipaddr2, ipaddr3 ]`  into the memcached.conf. This causes memcached to be unable to start due to bad syntax.  This fix makes listen_ip into an array called real_listen_ip and then joins all the array items together with a comma. Once this syntax is dumped into the memcache.conf file, Memcached is again able to start correctly.
