### PR TITLE
Add the logstdout bool parameter ti disable syslog/file logging completely

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ To change this behavior, you need to set listen_ip to '0.0.0.0'.
 
 * $package_ensure = 'present'
 * $logfile = '/var/log/memcached.log'
+* $logstdout = false (Set this to true to disable logging to a file/syslog entirely, useful when memcached runs in containers)
 * $pidfile = '/var/run/memcached.pid' (Debian family only, set to false to disable pidfile)
 * $max_memory = false
 * $max_item_size = false

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -11,6 +11,7 @@ class memcached (
   Enum['present', 'latest', 'absent'] $package_ensure                                        = 'present',
   Boolean $service_manage                                                                    = true,
   Optional[Stdlib::Absolutepath] $logfile                                                    = $::memcached::params::logfile,
+  Boolean $logstdout                                                                         = false,
   Boolean $syslog                                                                            = false,
   Optional[Stdlib::Absolutepath] $pidfile                                                    = '/var/run/memcached.pid',
   Boolean $manage_firewall                                                                   = false,

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -379,6 +379,28 @@ describe 'memcached' do
         )
       end
     end
+
+    describe 'when setting logstdout to true' do
+      let :custom_params do
+        {
+          'logstdout' => true
+        }
+      end
+
+      let :param_hash do
+        default_params.merge(custom_params)
+      end
+
+      let :params do
+        custom_params
+      end
+
+      it do
+        is_expected.to contain_file('/etc/sysconfig/memcached').with_content(
+          "PORT=\"11211\"\nUSER=\"memcached\"\nMAXCONN=\"8192\"\nCACHESIZE=\"950\"\nOPTIONS=\"-l 127.0.0.1 -U 11211 -t 4\"\n"
+        )
+      end
+    end
   end
 end
 # vim: expandtab shiftwidth=2 softtabstop=2

--- a/templates/memcached_sysconfig.erb
+++ b/templates/memcached_sysconfig.erb
@@ -32,12 +32,14 @@ if @disable_cachedump
 end
 result << '-t ' + @processorcount.to_s
 
-# log to syslog via logger
-if @syslog && !@logfile
-	result << '2>&1 |/bin/logger &'
-# log to log file
-elsif @logfile && !@syslog
-  result << '>> ' + @logfile + ' 2>&1'
+if !@logstdout
+  # log to syslog via logger
+  if @syslog && !@logfile
+    result << '2>&1 |/bin/logger &'
+  # log to log file
+  elsif @logfile && !@syslog
+    result << '>> ' + @logfile + ' 2>&1'
+  end
 end
 -%>
 <%- if scope['osfamily'] != 'Suse' -%>


### PR DESCRIPTION
In PR https://github.com/saz/puppet-memcached/pull/88 we made the
sysconfig configuration work with undef values. So simply passing
an undef value for logfile should allow memcached to log to
stdout/stderr. The problem is that setting an undef value on a
parameter that already has a default value does not really work in puppet:
https://tickets.puppetlabs.com/browse/PUP-5295

So basically it becomes impossible to configure memcached to log to
stdout via hiera.

Let's add a "logstdout" parameter defaulting to false, which will
omit the syslog/logfile configuration when set to true.

Tested as follows:
$ hiera -c /etc/puppet/hiera.yaml memcached::logstdout && puppet apply -e 'include ::memcached' 2>&1 > /dev/null && cat /etc/sysconfig/memcached
true
PORT="11211"
USER="memcached"
MAXCONN="8192"
CACHESIZE="5877"
OPTIONS="-v -l 172.16.2.13 -U 0 -X -t 2"

$ hiera -c /etc/puppet/hiera.yaml memcached::logstdout && puppet apply -e 'include ::memcached' 2>&1 > /dev/null && cat /etc/sysconfig/memcached
false
PORT="11211"
USER="memcached"
MAXCONN="8192"
CACHESIZE="5877"
OPTIONS="-v -l 172.16.2.13 -U 0 -X -t 2 >> /var/log/memcached.log 2>&1"