### PR TITLE
allow FreeBSD to set max memory

### DIFF
--- a/templates/memcached_freebsd_rcconf.erb
+++ b/templates/memcached_freebsd_rcconf.erb
@@ -9,15 +9,11 @@ end
 
 flags = []
 # required flags
-flags << "-d -u #{@user} -P #{@pidfile} -t #{@processorcount}"
+flags << "-d -u #{@user} -P #{@pidfile} -t #{@processorcount} -m #{@max_memory}"
 
 # optional flags
 if @item_size
   flags << "-I #{@item_size.to_s}"
-end
-
-if @max_memory
-  flags << "-m #{@max_memory}"
 end
 
 if @real_listen_ip

--- a/templates/memcached_freebsd_rcconf.erb
+++ b/templates/memcached_freebsd_rcconf.erb
@@ -16,6 +16,10 @@ if @item_size
   flags << "-I #{@item_size.to_s}"
 end
 
+if @max_memory
+  flags << "-m #{@max_memory}"
+end
+
 if @real_listen_ip
   flags << "-l #{@real_listen_ip.join(',')}"
 end


### PR DESCRIPTION
Currently, the freebsd's conf file don't read the maxmemory var. I add it.