### PR TITLE
Updating version dependencies

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -12,8 +12,8 @@
     {"name":"puppet","version_requirement":">= 4.0.0 < 6.0.0" }
   ],
   "dependencies": [
-    {"name":"puppetlabs/stdlib","version_requirement":">= 4.13.1 < 6.0.0"},
-    {"name":"puppetlabs/firewall","version_requirement":">= 0.1.0 < 2.0.0"}
+    {"name":"puppetlabs/stdlib","version_requirement":">= 4.13.1 < 7.0.0"},
+    {"name":"puppetlabs/firewall","version_requirement":">= 0.1.0 < 3.0.0"}
   ],
   "operatingsystem_support": [
     {


### PR DESCRIPTION
Updating version dependencies for firewall and stdlib. These versions have been publicly available for a while now and don't appear to break anything.