### PR TITLE
Make ssl_ca_cert optional

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -55,6 +55,12 @@ class memcached (
     fail 'Define either syslog or logfile as logging destinations but not both.'
   }
 
+  if $use_tls {
+    if $tls_cert_chain == undef or $tls_key == undef {
+      fail 'tls_cert_chain and tls_key should be set when use_tls is true.'
+    }
+  }
+
   if $package_ensure == 'absent' {
     $service_ensure = 'stopped'
     $service_enable = false

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -16,7 +16,8 @@ describe 'memcached' do
       use_tls: false,
       large_mem_pages: false,
       pidfile: '/var/run/memcached.pid',
-      disable_cachedump: false
+      disable_cachedump: false,
+      tls_verify_mode: 1
     }
   end
 
@@ -103,6 +104,17 @@ describe 'memcached' do
    },
    {
      listen_ip: ['127.0.0.1', '127.0.0.2']
+   },
+   {
+     use_tls: true,
+     tls_cert_chain: '/path/to/cert',
+     tls_key: '/path/to/key',
+     tls_ca_cert: '/path/to/cacert'
+   },
+   {
+     use_tls: true,
+     tls_cert_chain: '/path/to/cert',
+     tls_key: '/path/to/key'
    },
    {
      service_manage: false
@@ -200,7 +212,9 @@ describe 'memcached' do
                 flags.push('-Z')
                 flags.push("-o ssl_chain_cert=#{param_hash[:tls_cert_chain]}")
                 flags.push("-o ssl_key=#{param_hash[:tls_key]}")
-                flags.push("-o ssl_ca_cert=#{param_hash[:tls_ca_cert]}")
+                if param_hash[:tls_ca_cert]
+                  flags.push("-o ssl_ca_cert=#{param_hash[:tls_ca_cert]}")
+                end
                 flags.push("-o ssl_verify_mode=#{param_hash[:tls_verify_mode]}")
               end
 
@@ -311,7 +325,9 @@ describe 'memcached' do
               expected_lines.push('-Z')
               expected_lines.push("-o ssl_chain_cert=#{param_hash[:tls_cert_chain]}")
               expected_lines.push("-o ssl_key=#{param_hash[:tls_key]}")
-              expected_lines.push("-o ssl_ca_cert=#{param_hash[:tls_ca_cert]}")
+              if param_hash[:tls_ca_cert]
+                expected_lines.push("-o ssl_ca_cert=#{param_hash[:tls_ca_cert]}")
+              end
               expected_lines.push("-o ssl_verify_mode=#{param_hash[:tls_verify_mode]}")
             end
             expected_lines.push('-L') if param_hash[:large_mem_pages]

--- a/templates/memcached.conf.erb
+++ b/templates/memcached.conf.erb
@@ -34,7 +34,9 @@ logfile <%= @logfile -%>
 -Z
 -o ssl_chain_cert=<%= @tls_cert_chain %>
 -o ssl_key=<%= @tls_key %>
+<% if @tls_ca_cert -%>
 -o ssl_ca_cert=<%= @tls_ca_cert %>
+<% end -%>
 -o ssl_verify_mode=<%= @tls_verify_mode %>
 <% end -%>
 

--- a/templates/memcached_freebsd_rcconf.erb
+++ b/templates/memcached_freebsd_rcconf.erb
@@ -58,7 +58,9 @@ if @use_tls
   flags << "-Z"
   flags << "-o ssl_chain_cert=#{@tls_cert_chain}"
   flags << "-o ssl_key=#{@tls_key}"
-  flags << "-o ssl_ca_cert=#{@tls_ca_cert}"
+  if @tls_ca_cert
+    flags << "-o ssl_ca_cert=#{@tls_ca_cert}"
+  end
   flags << "-o ssl_verify_mode=#{@tls_verify_mode}"
 end
 

--- a/templates/memcached_svcprop.erb
+++ b/templates/memcached_svcprop.erb
@@ -24,7 +24,9 @@ if @use_tls
   result << '"-Z"'
   result << '"-o" "ssl_chain_cert="' + @tls_cert_chain + '"'
   result << '"-o" "ssl_key="' + @tls_key + '"'
-  result << '"-o" "ssl_ca_cert="' + @tls_ca_cert + '"'
+  if @tls_ca_cert
+    result << '"-o" "ssl_ca_cert="' + @tls_ca_cert + '"'
+  end
   result << '"-o" "ssl_verify_mode="' + @tls_verify_mode + '"'
 end
 


### PR DESCRIPTION
When TLS is enabled, memcached requires ssl_key and ssl_chain_cert,
but ssl_ca_cert is optional. Thus we shouldn't set that option if
ca cert is unnecessary.