### PR TITLE
Add support to set TLS parameters in /etc/sysconfig/memcached

### DIFF
--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -475,6 +475,56 @@ describe 'memcached' do
         )
       end
     end
+
+    describe 'when setting use_tls to true' do
+      let :custom_params do
+        {
+          'use_tls'         => true,
+          'tls_cert_chain'  => '/path/to/cert',
+          'tls_key'         => '/path/to/key',
+          'tls_ca_cert'     => '/path/to/cacert',
+          'tls_verify_mode' => 0
+        }
+      end
+
+      let :param_hash do
+        default_params.merge(custom_params)
+      end
+
+      let :params do
+        custom_params
+      end
+
+      it do
+        is_expected.to contain_file('/etc/sysconfig/memcached').with_content(
+          "PORT=\"11211\"\nUSER=\"memcached\"\nMAXCONN=\"8192\"\nCACHESIZE=\"950\"\nOPTIONS=\"-l 127.0.0.1 -U 11211 -t 4 -Z -o ssl_chain_cert=/path/to/cert -o ssl_key=/path/to/key -o ssl_ca_cert=/path/to/cacert -o ssl_verify_mode=0 >> /var/log/memcached.log 2>&1\"\n"
+        )
+      end
+    end
+
+    describe 'when setting use_tls to true and unset tls_ca_cert' do
+      let :custom_params do
+        {
+          'use_tls'        => true,
+          'tls_cert_chain' => '/path/to/cert',
+          'tls_key'        => '/path/to/key'
+        }
+      end
+
+      let :param_hash do
+        default_params.merge(custom_params)
+      end
+
+      let :params do
+        custom_params
+      end
+
+      it do
+        is_expected.to contain_file('/etc/sysconfig/memcached').with_content(
+          "PORT=\"11211\"\nUSER=\"memcached\"\nMAXCONN=\"8192\"\nCACHESIZE=\"950\"\nOPTIONS=\"-l 127.0.0.1 -U 11211 -t 4 -Z -o ssl_chain_cert=/path/to/cert -o ssl_key=/path/to/key -o ssl_verify_mode=1 >> /var/log/memcached.log 2>&1\"\n"
+        )
+      end
+    end
   end
 end
 # vim: expandtab shiftwidth=2 softtabstop=2

--- a/templates/memcached_sysconfig.erb
+++ b/templates/memcached_sysconfig.erb
@@ -31,6 +31,15 @@ if @disable_cachedump
   result << '-X'
 end
 result << '-t ' + @processorcount.to_s
+if @use_tls
+  result << '-Z'
+  result << '-o ssl_chain_cert=' + @tls_cert_chain
+  result << '-o ssl_key=' + @tls_key
+  if @tls_ca_cert
+    result << '-o ssl_ca_cert=' + @tls_ca_cert
+  end
+  result << '-o ssl_verify_mode=' + @tls_verify_mode.to_s
+end
 
 if !@logstdout
   # log to syslog via logger


### PR DESCRIPTION
This patch makes tls parameters applied in /etc/sysconfig/memcached
on CentOS, so that memcached is started with tls enabled when managed
by systemd.
