### PR TITLE
Manage multiple memcached instances #106

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,26 @@ To change this behavior, you need to set listen_ip to '0.0.0.0'.
     }
 ```
 
+### Install multiple memcached instances
+
+```ruby
+    include memcached::params
+    memcached::instance { 'memcached_fpc':
+      tcp_port => 11212,
+      udp_port => 11212,
+      max_item_size => '4m',
+      max_memory => '50%',
+      listen_ip => '0.0.0.0',
+    }
+    
+    memcached::instance { 'memcached_session':
+      tcp_port => 11213,
+      udp_port => 11213,
+      max_item_size => '2m',
+      max_memory => '30%',
+      listen_ip => '0.0.0.0',
+    }
+```
 ### Other class parameters
 
 * $package_ensure = 'present'

--- a/manifests/instance.pp
+++ b/manifests/instance.pp
@@ -83,7 +83,7 @@ define memcached::instance (
 
   if $install_dev {
     ensure_resource('package', $memcached::params::dev_package_name, {
-     ensure  => $package_ensure,
+      ensure  => $package_ensure,
       require => Package[$memcached::params::package_name],
     })
   }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -6,25 +6,35 @@ class memcached::params {
       $package_name      = 'memcached'
       $package_provider  = undef
       $service_name      = 'memcached'
+      $service_path      = '/lib/systemd/system/'
+      $service_tmpl      = "${module_name}/memcached_systemd.erb"
       $service_hasstatus = false
       $dev_package_name  = 'libmemcached-dev'
-      $config_file       = '/etc/memcached.conf'
+      $config_path       = '/etc/'
+      $config_ext        = '.conf'
+      $config_file       = "${config_path}${service_name}${config_ext}"
       $config_tmpl       = "${module_name}/memcached.conf.erb"
       $user              = 'nobody'
-      $logfile           = '/var/log/memcached.log'
+      $logpath           = '/var/log/'
+      $logfile           = "${logpath}${service_name}.log"
       $use_registry      = false
       $use_svcprop       = false
     }
     /RedHat|Suse/: {
       $package_name      = 'memcached'
       $package_provider  = undef
+      $user              = 'memcached'
       $service_name      = 'memcached'
+      $service_path      = '/usr/lib/systemd/system/'
+      $service_tmpl      = "${module_name}/memcached_systemd.service.erb"
       $service_hasstatus = true
       $dev_package_name  = 'libmemcached-devel'
-      $config_file       = '/etc/sysconfig/memcached'
+      $config_path       = '/etc/sysconfig/'
+      $config_ext        = ''
+      $config_file       = "${config_path}${service_name}${config_ext}"
       $config_tmpl       = "${module_name}/memcached_sysconfig.erb"
-      $user              = 'memcached'
-      $logfile           = '/var/log/memcached.log'
+      $logpath           = '/var/log/'
+      $logfile           = "${logpath}${service_name}.log"
       $use_registry      = false
       $use_svcprop       = false
     }
@@ -34,9 +44,12 @@ class memcached::params {
       $service_name      = 'memcached'
       $service_hasstatus = true
       $dev_package_name  = 'libmemcached-devel'
+      $config_path       = undef
+      $config_ext        = undef
       $config_file       = undef
       $config_tmpl       = "${module_name}/memcached_windows.erb"
       $user              = 'BUILTIN\Administrators'
+      $logpath           = undef
       $logfile           = undef
       $use_registry      = true
       $use_svcprop       = false
@@ -47,10 +60,13 @@ class memcached::params {
       $service_name      = 'memcached'
       $service_hasstatus = false
       $dev_package_name  = 'libmemcached'
+      $config_path       = undef
+      $config_ext        = undef
       $config_file       = undef
       $config_tmpl       = "${module_name}/memcached_svcprop.erb"
       $user              = 'nobody'
-      $logfile           = '/var/log/memcached.log'
+      $logpath           = '/var/log/'
+      $logfile           = "${logpath}${service_name}.log"
       $use_registry      = false
       $use_svcprop       = true
     }
@@ -60,10 +76,13 @@ class memcached::params {
       $service_name      = 'memcached'
       $service_hasstatus = false
       $dev_package_name  = 'libmemcached'
-      $config_file       = '/etc/rc.conf.d/memcached'
+      $config_path       = '/etc/rc.conf.d/'
+      $config_ext        = ''
+      $config_file       = "${config_path}${service_name}${config_ext}"
       $config_tmpl       = "${module_name}/memcached_freebsd_rcconf.erb"
       $user              = 'nobody'
-      $logfile           = '/var/log/memcached.log'
+      $logpath           = '/var/log/'
+      $logfile           = "${logpath}${service_name}.log"
       $use_registry      = false
       $use_svcprop       = false
     }
@@ -73,12 +92,17 @@ class memcached::params {
           $package_name      = 'memcached'
           $package_provider  = undef
           $service_name      = 'memcached'
+          $service_path      = '/usr/lib/systemd/system/'
+          $service_tmpl      = "${module_name}/memcached_systemd.service.erb"
           $service_hasstatus = true
           $dev_package_name  = 'libmemcached-devel'
-          $config_file       = '/etc/sysconfig/memcached'
+          $config_path       = '/etc/sysconfig/'
+          $config_ext        = ''
+          $config_file       = "${config_path}${service_name}${config_ext}"
           $config_tmpl       = "${module_name}/memcached_sysconfig.erb"
           $user              = 'memcached'
-          $logfile           = '/var/log/memcached.log'
+          $logpath           = '/var/log/'
+          $logfile           = "${logpath}${service_name}.log"
           $use_registry      = false
           $use_svcprop       = false
         }

--- a/templates/memcached_systemd.erb
+++ b/templates/memcached_systemd.erb
@@ -1,0 +1,10 @@
+[Unit]
+Description=<%= @service_name %> service
+After=network.target
+Documentation=man:memcached(1)
+
+[Service]
+ExecStart=/usr/share/memcached/scripts/systemd-memcached-wrapper <%= @config_file %>
+
+[Install]
+WantedBy=multi-user.target

--- a/templates/memcached_systemd.service.erb
+++ b/templates/memcached_systemd.service.erb
@@ -1,0 +1,12 @@
+[Unit]
+Description=<%= @service_name %> service
+Before=httpd.service
+After=network.target
+
+[Service]
+Type=simple
+EnvironmentFile=-<%= @config_file %>
+ExecStart=/usr/bin/memcached -u $USER -p $PORT -m $CACHESIZE -c $MAXCONN $OPTIONS
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
Ressource memcached::instance created to manage multiple instances.
Class "memcached" works as before to unsure the compability.
Tested on CentOS 8 and Debian 9