### PR TITLE
Drop EOL Puppet 4 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,19 +15,15 @@ matrix:
   fast_finish: true
   include:
   - rvm: 2.3.1
-    env: PUPPET_VERSION="~> 4.0" STRICT_VARIABLES="yes" CHECK=test
+    env: PUPPET_VERSION="~> 5.0" CHECK=build FORGEDEPLOY=true
   - rvm: 2.3.1
-    env: PUPPET_VERSION="~> 4.0" STRICT_VARIABLES="yes" CHECK=rubocop
+    env: PUPPET_VERSION="~> 5.0" CHECK=test
   - rvm: 2.3.1
-    env: PUPPET_VERSION="~> 4.0" STRICT_VARIABLES="yes" CHECK=build FORGEDEPLOY=true
-  - rvm: 2.3.1
-    env: PUPPET_VERSION="~> 5.0" STRICT_VARIABLES="yes" CHECK=test
-  - rvm: 2.3.1
-    env: PUPPET_VERSION="~> 5.0" STRICT_VARIABLES="yes" CHECK=rubocop
+    env: PUPPET_VERSION="~> 5.0" CHECK=rubocop
   - rvm: 2.5.3
-    env: PUPPET_VERSION="~> 6.1" STRICT_VARIABLES="yes" CHECK=test
+    env: PUPPET_VERSION="~> 6.1" CHECK=test
   - rvm: 2.5.3
-    env: PUPPET_VERSION="~> 6.1" STRICT_VARIABLES="yes" CHECK=rubocop
+    env: PUPPET_VERSION="~> 6.1" CHECK=rubocop
 notifications:
   email: false
 deploy:

--- a/Gemfile
+++ b/Gemfile
@@ -57,7 +57,7 @@ else
   gem 'facter', require: false, groups: [:test]
 end
 
-ENV['PUPPET_VERSION'].nil? ? puppetversion = '~> 4.0' : puppetversion = ENV['PUPPET_VERSION'].to_s
+ENV['PUPPET_VERSION'].nil? ? puppetversion = '~> 6.0' : puppetversion = ENV['PUPPET_VERSION'].to_s
 gem 'puppet', puppetversion, require: false, groups: [:test]
 
 # vim: syntax=ruby

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Manage memcached via Puppet
 If you find this module useful, send some bitcoins to 1Na3YFUmdxKxJLiuRXQYJU2kiNqA3KY2j9
 
 ### Supported Puppet versions
-* Puppet >= 4
+* Puppet >= 5
 * Last version supporting Puppet 3: v3.0.2
 
 ## How to use

--- a/metadata.json
+++ b/metadata.json
@@ -9,7 +9,7 @@
   "issues_url": "https://github.com/saz/puppet-memcached/issues",
   "description": "Manage memcached via Puppet",
   "requirements": [
-    {"name":"puppet","version_requirement":">= 4.0.0 < 7.0.0" }
+    {"name":"puppet","version_requirement":">= 5.5.8 < 7.0.0" }
   ],
   "dependencies": [
     {"name":"puppetlabs/stdlib","version_requirement":">= 4.13.1 < 7.0.0"},


### PR DESCRIPTION
Puppet 4 is EOL since a long time. This PR drops it from the travis
matrix and also from the metadata.json.