### PR TITLE
Adds sasl support to RHEL derivatives

### DIFF
--- a/templates/memcached_sysconfig.erb
+++ b/templates/memcached_sysconfig.erb
@@ -40,6 +40,9 @@ if @use_tls
   end
   result << '-o ssl_verify_mode=' + @tls_verify_mode.to_s
 end
+if @use_sasl
+  result << '-S'
+end
 
 if !@logstdout
   # log to syslog via logger


### PR DESCRIPTION
SASL support wasn't enabled in the template file for rhel systems. I made the change and would like to see this incorporated into the release.