### PR TITLE
Add notls_listener_addr and notls_listener_port paramenters

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,4 +137,6 @@ memcached::instance{'11222':
 * $tls_key = undef
 * $tls_ca_cert = undef
 * $tls_verify_mode = 1 (0: None, 1: Request, 2: Require, 3: Once)
+* $notls_listener_addr = '127.0.0.1'
+* $notls_listener_port = undef
 * $large_mem_pages = false (try to use large memory pages)

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -38,6 +38,8 @@ class memcached (
   Optional[Stdlib::Absolutepath] $tls_key                                                    = undef,
   Optional[Stdlib::Absolutepath] $tls_ca_cert                                                = undef,
   Optional[Integer] $tls_verify_mode                                                         = 1,
+  Optional[Stdlib::IP::Address] $notls_listener_addr                                         = '127.0.0.1',
+  Optional[Stdlib::Port] $notls_listener_port                                                = undef,
   Boolean $use_registry                                                                      = $memcached::params::use_registry,
   String $registry_key                                                                       = 'HKLM\System\CurrentControlSet\services\memcached\ImagePath',
   Boolean $large_mem_pages                                                                   = false,

--- a/templates/memcached.conf.erb
+++ b/templates/memcached.conf.erb
@@ -38,6 +38,9 @@ logfile <%= @logfile -%>
 -o ssl_ca_cert=<%= @tls_ca_cert %>
 <% end -%>
 -o ssl_verify_mode=<%= @tls_verify_mode %>
+<% if @notls_listener_port -%>
+-l notls:<%= @notls_listener_addr %>:<%= @notls_listener_port %>
+<% end -%>
 <% end -%>
 
 <% if @unix_socket -%>

--- a/templates/memcached_freebsd_rcconf.erb
+++ b/templates/memcached_freebsd_rcconf.erb
@@ -62,6 +62,9 @@ if @use_tls
     flags << "-o ssl_ca_cert=#{@tls_ca_cert}"
   end
   flags << "-o ssl_verify_mode=#{@tls_verify_mode}"
+  if @notls_listener_port
+    flags << "-l notls:#{@notls_listener_addr}:#{@notls_listener_port}"
+  end
 end
 
 if @large_mem_pages

--- a/templates/memcached_svcprop.erb
+++ b/templates/memcached_svcprop.erb
@@ -28,6 +28,9 @@ if @use_tls
     result << '"-o" "ssl_ca_cert="' + @tls_ca_cert + '"'
   end
   result << '"-o" "ssl_verify_mode="' + @tls_verify_mode + '"'
+  if @notls_listener_port
+    result << '"-l" "notls:"' + @notls_listener_addr + ':' + @notls_listener_port + '"'
+  end
 end
 
 if @unix_socket

--- a/templates/memcached_sysconfig.erb
+++ b/templates/memcached_sysconfig.erb
@@ -39,6 +39,9 @@ if @use_tls
     result << '-o ssl_ca_cert=' + @tls_ca_cert
   end
   result << '-o ssl_verify_mode=' + @tls_verify_mode.to_s
+  if @notls_listener_port
+    result << '-l notls:' + @notls_listener_addr + ':' + @notls_listener_port
+  end
 end
 
 if !@logstdout


### PR DESCRIPTION
When running with TLS enabled, it is possible to also listen without TLS on a different port. These params are used to set the additional listener. Just by setting the port to listen will enable this feature and the listening address will default to 127.0.0.1, but can also be set via notls_listener_addr param.

I am not sure if I need to update spec/classes/init_spec.rb regarding to tls stuff.
