### PR TITLE
Disable UDP by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ memcached::instance{'11222':
 * $lock_memory = false (WARNING: good if used intelligently, google for -k key)
 * $listen_ip = '127.0.0.1'
 * $tcp_port = 11211
-* $udp_port = 11211
+* $udp_port = 0
 * $manage_firewall = false
 * $user = '' (OS specific setting, see params.pp)
 * $max_connections = 8192

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -22,7 +22,7 @@ class memcached (
   Boolean $lock_memory                                                                       = false,
   Optional[Variant[Stdlib::Compat::Ip_address,Array[Stdlib::Compat::Ip_address]]] $listen_ip = '127.0.0.1',
   Integer $tcp_port                                                                          = 11211,
-  Integer $udp_port                                                                          = 11211,
+  Integer $udp_port                                                                          = 0,
   String $user                                                                               = $memcached::params::user,
   Integer $max_connections                                                                   = 8192,
   Optional[String] $verbosity                                                                = undef,
@@ -90,10 +90,12 @@ class memcached (
       action => 'accept',
     }
 
-    firewall { "100_udp_${udp_port}_for_memcached":
-      dport  => $udp_port,
-      proto  => 'udp',
-      action => 'accept',
+    if $udp_port != 0 {
+      firewall { "100_udp_${udp_port}_for_memcached":
+        dport  => $udp_port,
+        proto  => 'udp',
+        action => 'accept',
+      }
     }
   }
 

--- a/spec/acceptance/init_spec.rb
+++ b/spec/acceptance/init_spec.rb
@@ -16,7 +16,7 @@ describe 'memcached' do
     end
     describe port(11_211) do
       it { is_expected.to be_listening.on('127.0.0.1').with('tcp') }
-      it { is_expected.to be_listening.on('127.0.0.1').with('udp') }
+      it { is_expected.not_to be_listening.on('127.0.0.1').with('udp') }
     end
   end
 end

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -27,8 +27,21 @@ describe 'memcached' do
       end
 
       describe 'with manage_firewall parameter' do
-        context 'with manage_firewall set to true' do
+        context 'with manage_firewall set to true and unset udp_port' do
           let(:params) { { manage_firewall: true } }
+
+          it { is_expected.to contain_class('memcached') }
+
+          it { is_expected.to contain_firewall('100_tcp_11211_for_memcached') }
+        end
+
+        context 'with manage_firewall set to true and udp_port set to 11211' do
+          let :params do
+            {
+              'manage_firewall' => true,
+              'udp_port'        => 11_211
+            }
+          end
 
           it { is_expected.to contain_class('memcached') }
 
@@ -36,6 +49,7 @@ describe 'memcached' do
           it { is_expected.to contain_firewall('100_udp_11211_for_memcached') }
         end
       end
+
       describe 'when setting use_tls to true and unset tls_ca_cert' do
         let :params do
           {
@@ -48,7 +62,7 @@ describe 'memcached' do
         end
 
         context 'on RedHat', if: facts[:os]['family'] == 'RedHat' do
-          it { is_expected.to contain_file('/etc/sysconfig/memcached').with_content("PORT=\"11211\"\nUSER=\"memcached\"\nMAXCONN=\"8192\"\nCACHESIZE=\"462\"\nOPTIONS=\"-l 127.0.0.1 -U 11211 -t 1 -Z -o ssl_chain_cert=/path/to/cert -o ssl_key=/path/to/key -o ssl_ca_cert=/path/to/cacert -o ssl_verify_mode=0 >> /var/log/memcached.log 2>&1\"\n") }
+          it { is_expected.to contain_file('/etc/sysconfig/memcached').with_content("PORT=\"11211\"\nUSER=\"memcached\"\nMAXCONN=\"8192\"\nCACHESIZE=\"462\"\nOPTIONS=\"-l 127.0.0.1 -U 0 -t 1 -Z -o ssl_chain_cert=/path/to/cert -o ssl_key=/path/to/key -o ssl_ca_cert=/path/to/cacert -o ssl_verify_mode=0 >> /var/log/memcached.log 2>&1\"\n") }
         end
       end
     end


### PR DESCRIPTION
According to memcached, UDP is disabled by default since 1.5.6, turning it back on is a decision that should be left to the end user.

https://github.com/memcached/memcached/wiki/DDOS
