### PR TITLE
Fix TypeError on notls_listener_port.

### DIFF
--- a/templates/memcached_svcprop.erb
+++ b/templates/memcached_svcprop.erb
@@ -27,9 +27,9 @@ if @use_tls
   if @tls_ca_cert
     result << '"-o" "ssl_ca_cert="' + @tls_ca_cert + '"'
   end
-  result << '"-o" "ssl_verify_mode="' + @tls_verify_mode + '"'
+  result << '"-o" "ssl_verify_mode="' + @tls_verify_mode.to_s + '"'
   if @notls_listener_port
-    result << '"-l" "notls:"' + @notls_listener_addr + ':' + @notls_listener_port + '"'
+    result << '"-l" "notls:"' + @notls_listener_addr + ':' + @notls_listener_port.to_s + '"'
   end
 end
 

--- a/templates/memcached_sysconfig.erb
+++ b/templates/memcached_sysconfig.erb
@@ -40,7 +40,7 @@ if @use_tls
   end
   result << '-o ssl_verify_mode=' + @tls_verify_mode.to_s
   if @notls_listener_port
-    result << '-l notls:' + @notls_listener_addr + ':' + @notls_listener_port
+    result << '-l notls:' + @notls_listener_addr + ':' + @notls_listener_port.to_s
   end
 end
 if @use_sasl


### PR DESCRIPTION
Since ruby does not do implicit type conversions, we need to convert
the port number to String.

Signed-off-by: Moisés Guimarães de Medeiros <moguimar@redhat.com>