### PR TITLE
Add listen_addr option

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,8 @@ memcached::instance{'11222':
 * $min_item_size = false
 * $factor = false
 * $lock_memory = false (WARNING: good if used intelligently, google for -k key)
-* $listen_ip = '127.0.0.1'
+* $listen = '127.0.0.1' (if TLS/SSL is enabled, 'notls' prefix can be used to disable for specific listeners "notls:<ip>:<port>")
+* $listen_ip = '127.0.0.1' (deprecated, listen will take precedence over this)
 * $tcp_port = 11211
 * $udp_port = 0
 * $manage_firewall = false

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -20,6 +20,7 @@ class memcached (
   Optional[Variant[Integer, String]] $min_item_size                                          = undef,
   Optional[Variant[Integer, String]] $factor                                                 = undef,
   Boolean $lock_memory                                                                       = false,
+  Optional[Variant[String,Array[String]]] $listen                                            = undef,
   Optional[Variant[Stdlib::Compat::Ip_address,Array[Stdlib::Compat::Ip_address]]] $listen_ip = '127.0.0.1',
   Integer $tcp_port                                                                          = 11211,
   Integer $udp_port                                                                          = 0,
@@ -70,8 +71,13 @@ class memcached (
     $service_enable = true
   }
 
-  # Handle if $listen_ip is not an array
-  $real_listen_ip = [$listen_ip]
+  if $listen {
+    # Handle if $listen is not an array
+    $real_listen = [$listen]
+  } else {
+    # Handle if $listen_ip is not an array
+    $real_listen = [$listen_ip]
+  }
 
   package { $memcached::params::package_name:
     ensure   => $package_ensure,

--- a/templates/memcached.conf.erb
+++ b/templates/memcached.conf.erb
@@ -51,9 +51,9 @@ logfile <%= @logfile -%>
 -a <%= @unix_socket_mask %>
 <% else -%>
 
-<% if @real_listen_ip -%>
-# IP to listen on
--l <%= @real_listen_ip.join(',') %>
+<% if @real_listen -%>
+# interfaces to listen on
+-l <%= @real_listen.join(',') %>
 <% end -%>
 
 # TCP port to listen on

--- a/templates/memcached_freebsd_rcconf.erb
+++ b/templates/memcached_freebsd_rcconf.erb
@@ -16,8 +16,8 @@ if @item_size
   flags << "-I #{@item_size}"
 end
 
-if @real_listen_ip
-  flags << "-l #{@real_listen_ip.join(',')}"
+if @real_listen
+  flags << "-l #{@real_listen.join(',')}"
 end
 
 if @lock_memory

--- a/templates/memcached_svcprop.erb
+++ b/templates/memcached_svcprop.erb
@@ -40,9 +40,9 @@ if @unix_socket
   # UNIX socket access mask
   result << '"-a" "' + @unix_socket_mask + '"'
 else
-  if @real_listen_ip
-    # IP to listen on
-    result << '"-l" "' + @real_listen_ip.join(',') + '"'
+  if @real_listen
+    # interface to listen on
+    result << '"-l" "' + @real_listen.join(',') + '"'
   end
 
   # TCP port to listen on

--- a/templates/memcached_sysconfig.erb
+++ b/templates/memcached_sysconfig.erb
@@ -6,8 +6,8 @@ end
 if @lock_memory
   result << '-k'
 end
-if @real_listen_ip
-  result << '-l ' + @real_listen_ip.join(',')
+if @real_listen
+  result << '-l ' + @real_listen.join(',')
 end
 if @udp_port
   result << '-U ' + @udp_port.to_s

--- a/templates/memcached_windows.erb
+++ b/templates/memcached_windows.erb
@@ -6,8 +6,8 @@ end
 if @lock_memory
   result << '-k'
 end
-if @real_listen_ip
-  result << '-l ' + @real_listen_ip.join(',')
+if @real_listen
+  result << '-l ' + @real_listen.join(',')
 end
 if @tcp_port
   result << '-p ' + @tcp_port.to_s


### PR DESCRIPTION
The idea of this patch is to deprecate listen_ip in favor of listen_addr allowing more configuration flexibility.

I chose Optional[Variant[String,Array[String]]] instead of constructing a convoluted type for validation as both
memcached will validate the addresses and I lack the know how to do so. I'll be willing to patch with another type
if the type is provided.

Current option listen_ip only supports IP types (IPv4 and IPv6)
while memcached's -l option allows <host>:<port> or also notls:<host>:<port>
in case a nonTLS interface is required when deploying with TLS enabled.

So the following examples are valid calls of memcached:

run memcached at both port 11211 and 11212
$ memcached -p 11211 -l localhost,localhost:11212

run memcached with TLS on ipv4, but not ipv6
memcached -l "127.0.0.1,notls:[::1]:11211" \
          -Z -o ssl_chain_cert=cert.pem \
          -o ssl_key=key.key \
          -o ssl_ca_cert=tls/client-ca-root.crt \
          -o ssl_verify_mode=1

Signed-off-by: Moisés Guimarães de Medeiros <moguimar@redhat.com>