### PR TITLE
manifests/instance: Fix duplicate systemd daemon-reload execs

### DIFF
--- a/manifests/instance.pp
+++ b/manifests/instance.pp
@@ -53,10 +53,10 @@ define memcached::instance (
       unit    => $service_name,
       source  => $override_source,
       content => $override_content,
-      notify  => Exec['memcached_force_systemd_reload'],
+      notify  => Exec["${service_name}_force_systemd_reload"],
     }
 
-    exec { 'memcached_force_systemd_reload':
+    exec { "${service_name}_force_systemd_reload":
       command     => 'systemctl daemon-reload',
       user        => 'root',
       path        => ['/sbin', '/bin', '/usr/sbin', '/usr/bin'],


### PR DESCRIPTION
When declaring multiple instances running on different ports, Puppet trips over the `memcached_force_systemd_reload` exec resource, since it's a duplicate across multiple instances.