### PR TITLE
Load modern facts first

### DIFF
--- a/lib/puppet/functions/memcached/max_memory.rb
+++ b/lib/puppet/functions/memcached/max_memory.rb
@@ -18,17 +18,17 @@ Puppet::Functions.create_function(:'memcached::max_memory') do
       max_memory_percent = arg ? arg : '95%'
 
       # Taken from puppetlabs-stdlib to_bytes() function
-      value, prefix = *%r{([0-9.e+-]*)\s*([^bB]?)}.match(memsize)[1, 2]
+      value, suffix = *%r{([0-9.e+-]*)\s*([^bB]?)}.match(memsize)[1, 2]
 
       value = value.to_f
-      case prefix
+      case suffix
       when '' then value = value
       when 'k' then value *= (1 << 10)
       when 'M' then value *= (1 << 20)
       when 'G' then value *= (1 << 30)
       when 'T' then value *= (1 << 40)
       when 'E' then value *= (1 << 50)
-      else raise Puppet::ParseError, "memcached_max_memory(): Unknown prefix #{prefix}"
+      else raise Puppet::ParseError, "memcached_max_memory(): Unknown suffix #{suffix}"
       end
       value = value.to_i
       result_in_mb = ((value / (1 << 20)) * (max_memory_percent.to_f / 100.0)).floor

--- a/lib/puppet/functions/memcached/max_memory.rb
+++ b/lib/puppet/functions/memcached/max_memory.rb
@@ -6,7 +6,11 @@ Puppet::Functions.create_function(:'memcached::max_memory') do
 
   def max_memory(arg)
     scope = closure_scope
-    memsize = scope['facts']['memorysize']
+    memsize = if scope['facts']['memory'].nil?
+                scope['facts']['memorysize']
+              else
+                scope['facts']['memory']['system']['total']
+              end
 
     if arg && !arg.to_s.end_with?('%')
       result_in_mb = arg.to_i


### PR DESCRIPTION
This change introduces additional logic to load modern fact before
loading legacy fact. Legacy facts are not officially deprecated but
it's possible at some point these are disabled by default. (Actually
these are no longer included in facter command output by default now)