### PR TITLE
Support CentOS 8/RHEL 8

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -21,13 +21,15 @@
     {
       "operatingsystem": "RedHat",
       "operatingsystemrelease": [
-        "7"
+        "7",
+        "8"
       ]
     },
     {
       "operatingsystem": "CentOS",
       "operatingsystemrelease": [
-        "7"
+        "7",
+        "8"
       ]
     },
     {

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -53,6 +53,7 @@ describe 'memcached' do
       describe 'when setting use_tls to true and unset tls_ca_cert' do
         let :params do
           {
+            'processorcount'  => 1,
             'use_tls'         => true,
             'tls_cert_chain'  => '/path/to/cert',
             'tls_key'         => '/path/to/key',


### PR DESCRIPTION
This change adds CentOS 8 and RHEL 8 to supported operating systems.