### PR TITLE
Support CentOS 9/RHEL 9

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -22,14 +22,16 @@
       "operatingsystem": "RedHat",
       "operatingsystemrelease": [
         "7",
-        "8"
+        "8",
+        "9"
       ]
     },
     {
       "operatingsystem": "CentOS",
       "operatingsystemrelease": [
         "7",
-        "8"
+        "8",
+        "9"
       ]
     },
     {


### PR DESCRIPTION
This change marks CentOS 9 and RHEL 9 as supported operating systems.
These versions are quite similar to CentOS 8 and RHEL 8 and we don't
require any logic change.