### PR TITLE
Bump upper version of puppet-systemd

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -14,7 +14,7 @@
   "dependencies": [
     {"name":"puppetlabs/stdlib","version_requirement":">= 4.13.1 < 9.0.0"},
     {"name":"puppetlabs/firewall","version_requirement":">= 0.1.0 < 4.0.0"},
-    {"name":"puppet/systemd","version_requirement":">= 2.10.0 < 4.0.0"},
+    {"name":"puppet/systemd","version_requirement":">= 2.10.0 < 5.0.0"},
     {"name":"puppet/selinux","version_requirement":">= 3.2.0 < 4.0.0"}
   ],
   "operatingsystem_support": [


### PR DESCRIPTION
puppet-systemd v4.0.0[1] was released this year. None of the breaking changes made in this major bump affects this module so we can bump the upper version.

[1] https://github.com/voxpupuli/puppet-systemd/blob/master/CHANGELOG.md#v400-2023-01-27