### PR TITLE
Stop using deprecated Stdlib::Compat::Ip_address

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -21,7 +21,7 @@ class memcached (
   Optional[Variant[Integer, String]] $factor                                                 = undef,
   Boolean $lock_memory                                                                       = false,
   Optional[Variant[String,Array[String]]] $listen                                            = undef,
-  Optional[Variant[Stdlib::Compat::Ip_address,Array[Stdlib::Compat::Ip_address]]] $listen_ip = undef,
+  Optional[Variant[Stdlib::Ip::Address,Array[Stdlib::Ip::Address]]] $listen_ip               = undef,
   Integer $tcp_port                                                                          = 11211,
   Integer $udp_port                                                                          = 0,
   String $user                                                                               = $memcached::params::user,


### PR DESCRIPTION
Since https://github.com/puppetlabs/puppetlabs-stdlib/commit/fcbd4267fd830982e86041599d4eb11c2072a94a

the type `Stdlib::Compat::Ip_address` is no longer available.