### PR TITLE
Allow bollean=>false for pidfile

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -13,7 +13,7 @@ class memcached (
   Optional[Stdlib::Absolutepath] $logfile                                                    = $memcached::params::logfile,
   Boolean $logstdout                                                                         = false,
   Boolean $syslog                                                                            = false,
-  Variant[Stdlib::Absolutepath, Undef] $pidfile                                              = '/var/run/memcached.pid',
+  Variant[Stdlib::Absolutepath, Boolean, Undef] $pidfile                                     = '/var/run/memcached.pid',
   Boolean $manage_firewall                                                                   = false,
   $max_memory                                                                                = '95%',
   Optional[Variant[Integer, String]] $max_item_size                                          = undef,


### PR DESCRIPTION
Allow disabling the pidfile.
See https://github.com/saz/puppet-memcached/issues/142