### PR TITLE
Add support for OpenBSD

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,7 @@ memcached::instance{'11222':
 * $install_dev = false (TRUE if 'libmemcached-dev' package should be installed)
 * $processorcount = $::processorcount
 * $service_restart = true (restart service after configuration changes, false to prevent restarts)
+* $service_flags = '-l 127.0.0.1 -u _memcached -P /var/run/memcached.pid' (only relevant for OpenBSD, to configure the service)
 * $use_sasl = false (start memcached with SASL support)
 * $use_tls = false (start memcached with TLS support)
 * $tls_cert_chain = undef

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -10,6 +10,7 @@
 class memcached (
   Enum['present', 'latest', 'absent'] $package_ensure                                        = 'present',
   Boolean $service_manage                                                                    = true,
+  Optional[String] $service_flags                                                            = $memcached::params::service_flags,
   Optional[Stdlib::Absolutepath] $logfile                                                    = $memcached::params::logfile,
   Boolean $logstdout                                                                         = false,
   Boolean $syslog                                                                            = false,
@@ -98,7 +99,7 @@ class memcached (
     }
   }
 
-  if $manage_firewall {
+  if $facts['kernel'] == 'Linux' and $manage_firewall {
     firewall { "100_tcp_${tcp_port}_for_memcached":
       dport  => $tcp_port,
       proto  => 'tcp',
@@ -147,6 +148,7 @@ class memcached (
     service { $memcached::params::service_name:
       ensure     => $service_ensure,
       enable     => $service_enable,
+      flags      => $service_flags,
       hasrestart => true,
       hasstatus  => $memcached::params::service_hasstatus,
     }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -7,6 +7,7 @@ class memcached::params {
       $package_provider  = undef
       $service_name      = 'memcached'
       $service_hasstatus = false
+      $service_flags     = undef
       $dev_package_name  = 'libmemcached-dev'
       $config_file       = '/etc/memcached.conf'
       $config_tmpl       = "${module_name}/memcached.conf.erb"
@@ -20,6 +21,7 @@ class memcached::params {
       $package_provider  = undef
       $service_name      = 'memcached'
       $service_hasstatus = true
+      $service_flags     = undef
       $dev_package_name  = 'libmemcached-devel'
       $config_file       = '/etc/sysconfig/memcached'
       $config_tmpl       = "${module_name}/memcached_sysconfig.erb"
@@ -33,6 +35,7 @@ class memcached::params {
       $package_provider  = 'chocolatey'
       $service_name      = 'memcached'
       $service_hasstatus = true
+      $service_flags     = undef
       $dev_package_name  = 'libmemcached-devel'
       $config_file       = undef
       $config_tmpl       = "${module_name}/memcached_windows.erb"
@@ -46,6 +49,7 @@ class memcached::params {
       $package_provider  = undef
       $service_name      = 'memcached'
       $service_hasstatus = false
+      $service_flags     = undef
       $dev_package_name  = 'libmemcached'
       $config_file       = undef
       $config_tmpl       = "${module_name}/memcached_svcprop.erb"
@@ -59,11 +63,26 @@ class memcached::params {
       $package_provider  = undef
       $service_name      = 'memcached'
       $service_hasstatus = false
+      $service_flags     = undef
       $dev_package_name  = 'libmemcached'
       $config_file       = '/etc/rc.conf.d/memcached'
       $config_tmpl       = "${module_name}/memcached_freebsd_rcconf.erb"
       $user              = 'nobody'
       $logfile           = '/var/log/memcached.log'
+      $use_registry      = false
+      $use_svcprop       = false
+    }
+    'OpenBSD': {
+      $package_name      = 'memcached'
+      $package_provider  = undef
+      $service_name      = 'memcached'
+      $service_hasstatus = false
+      $service_flags     = '-l 127.0.0.1 -u _memcached -P /var/run/memcached.pid'
+      $dev_package_name  = 'libmemcached'
+      $config_file       = undef
+      $config_tmpl       = ''
+      $user              = '_memcached'
+      $logfile           = undef
       $use_registry      = false
       $use_svcprop       = false
     }
@@ -74,6 +93,7 @@ class memcached::params {
           $package_provider  = undef
           $service_name      = 'memcached'
           $service_hasstatus = true
+          $service_flags     = undef
           $dev_package_name  = 'libmemcached-devel'
           $config_file       = '/etc/sysconfig/memcached'
           $config_tmpl       = "${module_name}/memcached_sysconfig.erb"

--- a/metadata.json
+++ b/metadata.json
@@ -66,6 +66,12 @@
     },
     {
       "operatingsystem": "FreeBSD"
+    },
+    {
+      "operatingsystem": "OpenBSD",
+      "operatingsystemrelease": [
+        "7"
+      ]
     }
   ]
 }

--- a/spec/defines/instance_spec.rb
+++ b/spec/defines/instance_spec.rb
@@ -9,55 +9,57 @@ describe 'memcached::instance', type: :define do
         facts
       end
 
-      context 'with minimal params' do
-        let(:title) { '3489' }
+      if facts[:kernel] == 'Linux'
+        context 'with minimal params' do
+          let(:title) { '3489' }
 
-        it { is_expected.to compile.with_all_deps }
-        it { is_expected.to contain_class('memcached::instance::servicefile') }
-        it { is_expected.to contain_service('memcached@3489.service') }
-        it { is_expected.to contain_systemd__unit_file('memcached@.service') }
+          it { is_expected.to compile.with_all_deps }
+          it { is_expected.to contain_class('memcached::instance::servicefile') }
+          it { is_expected.to contain_service('memcached@3489.service') }
+          it { is_expected.to contain_systemd__unit_file('memcached@.service') }
 
-        context 'on selinux', if: facts[:os]['selinux']['enabled'] == true do
-          it { is_expected.to contain_selinux__port('allow-memcached@3489.service') }
+          context 'on selinux', if: facts[:os]['selinux']['enabled'] == true do
+            it { is_expected.to contain_selinux__port('allow-memcached@3489.service') }
+          end
+
+          context 'without selinux', if: facts[:os]['family'] != 'RedHat' do
+            it { is_expected.not_to contain_selinux__port('allow-memcached@3489.service') }
+          end
         end
 
-        context 'without selinux', if: facts[:os]['family'] != 'RedHat' do
-          it { is_expected.not_to contain_selinux__port('allow-memcached@3489.service') }
-        end
-      end
+        context 'with limits' do
+          let(:title) { '3489' }
 
-      context 'with limits' do
-        let(:title) { '3489' }
-
-        let :params do
-          {
-            limits: {
-              LimitNOFILE: 8192
+          let :params do
+            {
+              limits: {
+                LimitNOFILE: 8192
+              }
             }
-          }
+          end
+
+          it { is_expected.to compile.with_all_deps }
+          it { is_expected.to contain_class('memcached::instance::servicefile') }
+          it { is_expected.to contain_service('memcached@3489.service') }
+          it { is_expected.to contain_systemd__unit_file('memcached@.service') }
+          it { is_expected.to contain_systemd__Service_limits('memcached@3489.service') }
         end
 
-        it { is_expected.to compile.with_all_deps }
-        it { is_expected.to contain_class('memcached::instance::servicefile') }
-        it { is_expected.to contain_service('memcached@3489.service') }
-        it { is_expected.to contain_systemd__unit_file('memcached@.service') }
-        it { is_expected.to contain_systemd__Service_limits('memcached@3489.service') }
-      end
+        context 'with overrides' do
+          let(:title) { '3489' }
 
-      context 'with overrides' do
-        let(:title) { '3489' }
+          let :params do
+            {
+              override_content: "[Service]\nEnvironment='LISTEN=-l 0.0.0.0'"
+            }
+          end
 
-        let :params do
-          {
-            override_content: "[Service]\nEnvironment='LISTEN=-l 0.0.0.0'"
-          }
+          it { is_expected.to compile.with_all_deps }
+          it { is_expected.to contain_class('memcached::instance::servicefile') }
+          it { is_expected.to contain_service('memcached@3489.service') }
+          it { is_expected.to contain_systemd__unit_file('memcached@.service') }
+          it { is_expected.to contain_systemd__dropin_file('memcached@3489.service-override.conf') }
         end
-
-        it { is_expected.to compile.with_all_deps }
-        it { is_expected.to contain_class('memcached::instance::servicefile') }
-        it { is_expected.to contain_service('memcached@3489.service') }
-        it { is_expected.to contain_systemd__unit_file('memcached@.service') }
-        it { is_expected.to contain_systemd__dropin_file('memcached@3489.service-override.conf') }
       end
     end
   end


### PR DESCRIPTION
OpenBSD doesn't use a config file, it just passes flags to the service, via the service_flags.
Therefore most of the parameters are ignored. Some scaffolding is done, i.e. around firewall rules, and configuring instances.

To help prevent accidental breakage, a couple of tests related to OpenBSD added as well.