### PR TITLE
Drop workaround for Puppet 5

### DIFF
--- a/manifests/instance.pp
+++ b/manifests/instance.pp
@@ -50,21 +50,10 @@ define memcached::instance (
     if $override_content and $override_source {
       fail('memcached::instance: you can only set override_content OR override_source, dont set both')
     }
-    # manually reload systemd to make puppet 5 users happy.
-    # puppet 6 and newer are reloading systemd properly
     systemd::dropin_file { "${service_name}-override.conf":
       unit    => $service_name,
       source  => $override_source,
       content => $override_content,
-      notify  => Exec["${service_name}_force_systemd_reload"],
-    }
-
-    exec { "${service_name}_force_systemd_reload":
-      command     => 'systemctl daemon-reload',
-      user        => 'root',
-      path        => ['/sbin', '/bin', '/usr/sbin', '/usr/bin'],
-      refreshonly => true,
-      notify      => Service[$service_name],
     }
   }
 


### PR DESCRIPTION
Remove the workaround which manually reload systemd daemons because it is no longer required in all supported Puppet versions. Furthermore the reload command is implemented in puppet-systemd since 3.10.0[1].

[1] https://github.com/voxpupuli/puppet-systemd/commit/2ed469f3097afa1f658f20318de267427478d88d