### PR TITLE
Bump upper limit of puppet-systemd

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -14,7 +14,7 @@
   "dependencies": [
     {"name":"puppetlabs/stdlib","version_requirement":">= 4.13.1 < 10.0.0"},
     {"name":"puppetlabs/firewall","version_requirement":">= 0.1.0 < 9.0.0"},
-    {"name":"puppet/systemd","version_requirement":">= 6.0.0 < 8.0.0"},
+    {"name":"puppet/systemd","version_requirement":">= 6.0.0 < 9.0.0"},
     {"name":"puppet/selinux","version_requirement":">= 3.2.0 < 5.0.0"}
   ],
   "operatingsystem_support": [


### PR DESCRIPTION
Currently we are using this module with puppet-systemd v8.1.0 without any issues.