### PR TITLE
Remove Scientific LINUX

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -39,12 +39,6 @@
       ]
     },
     {
-      "operatingsystem": "Scientific",
-      "operatingsystemrelease": [
-        "7"
-      ]
-    },
-    {
       "operatingsystem": "Debian",
       "operatingsystemrelease": [
         "11",


### PR DESCRIPTION
It reached its EOL on Dec 7, 2022, since CERN and Fermilab switched to AlmaLinux, which is explained in [1].

[1] https://scientificlinux.org/