### PR TITLE
Adding extra config to allow any configuration to be added

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,14 @@ For the old behaviour, you need to set listen to '0.0.0.0'.
     }
 ```
 
+### Keep persistent data upon service restart (https://docs.memcached.org/features/restart/)
+
+```ruby
+    class { 'memcached':
+      extra_config => ["-e /tmpfs_mount/memory_file"]
+    }
+```
+
 ### Install multiple memcached instances
 
 the multiinstance support uses a systemd instance unit file. This will be placed

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -118,6 +118,9 @@
 # @param extended_opts
 #   Array of extended options
 #
+# @param extra_config
+#   Array of extended configarion options
+#
 # @param config_tmpl
 #   Use a different config template
 #
@@ -177,6 +180,7 @@ class memcached (
   String $svcprop_fmri                                                                       = 'memcached:default',
   String $svcprop_key                                                                        = 'memcached/options',
   Optional[Array[String]] $extended_opts                                                     = undef,
+  Optional[Array[String]] $extra_config                                                      = undef,
   String $config_tmpl                                                                        = $memcached::params::config_tmpl,
   Boolean $disable_cachedump                                                                 = false,
   Optional[Integer] $max_reqs_per_event                                                      = undef,

--- a/templates/memcached.conf.erb
+++ b/templates/memcached.conf.erb
@@ -98,6 +98,10 @@ logfile <%= @logfile -%>
 -o <%= @extended_opts.join(',') -%>
 <% end -%>
 
+<% if @extra_config -%>
+<%= @extra_config.join(',') -%>
+<% end -%>
+
 <% if @disable_cachedump -%>
 -X
 <% end -%>


### PR DESCRIPTION
Adding param extra_config that will allow any extra configuration to be added to Memcached configuration file. Useful for example to add persistent data when restarting Memcached service but can be used for anything added in the future as well.