### PR TITLE
Accept integer value for max_memory

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -153,7 +153,7 @@ Default value: `false`
 
 ##### <a name="-memcached--max_memory"></a>`max_memory`
 
-Data type: `String[1]`
+Data type: `Variant[Integer[0], Pattern[/^1?\d?\d%$/]]`
 
 Max memory memcached should use to store items. Either in percent or mb
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -146,7 +146,7 @@ class memcached (
   Boolean $syslog                                                                            = false,
   Variant[Stdlib::Absolutepath, Boolean[false], Undef] $pidfile                              = $memcached::params::pidfile,
   Boolean $manage_firewall                                                                   = false,
-  String[1] $max_memory                                                                      = '95%',
+  Variant[Integer[0], Pattern[/^1?\d?\d%$/]] $max_memory                                     = '95%',
   Optional[Variant[Integer, String]] $max_item_size                                          = undef,
   Optional[Variant[Integer, String]] $min_item_size                                          = undef,
   Optional[Variant[Integer, String]] $factor                                                 = undef,


### PR DESCRIPTION
#### Pull Request (PR) description
Integer values have been used to describe memory amount in MiB.
Also apply the string pattern to make sure that given string is in 'N%' format.

#### This Pull Request (PR) fixes the following issues
Fixes #186
