### PR TITLE
puppet/systemd: allow 9.x

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -25,7 +25,7 @@
     },
     {
       "name": "puppet/systemd",
-      "version_requirement": ">= 6.0.0 < 9.0.0"
+      "version_requirement": ">= 6.0.0 < 10.0.0"
     },
     {
       "name": "puppet/selinux",


### PR DESCRIPTION
#### Pull Request (PR) description
Bump upper cap of puppet-systemd to allow 9.x . The latest version at the time of writing is 9.0.1 .

#### This Pull Request (PR) fixes the following issues
N/A
