### PR TITLE
Fix removed Systemd::ServiceLimits type on instance limits param

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -488,7 +488,7 @@ Default value: `Integer($name)`
 
 ##### <a name="-memcached--instance--limits"></a>`limits`
 
-Data type: `Optional[Systemd::ServiceLimits]`
+Data type: `Optional[Systemd::Unit::Service]`
 
 systemd limits for the service
 

--- a/manifests/instance.pp
+++ b/manifests/instance.pp
@@ -13,7 +13,7 @@
 define memcached::instance (
   Boolean $manage_firewall                      = false,
   Stdlib::Port::Unprivileged $port              = Integer($name),
-  Optional[Systemd::ServiceLimits] $limits      = undef,
+  Optional[Systemd::Unit::Service] $limits      = undef,
   Optional[String[1]] $override_content         = undef,
   Optional[Stdlib::Filesource] $override_source = undef,
 ) {


### PR DESCRIPTION
#### Pull Request (PR) description

`puppet/systemd` deprecated `systemd::service_limits` and its `Systemd::ServiceLimits` type in v7.0.0 and removed the type in a recent change in the default branch (absent from current). `memcached::instance` still declared `Optional[Systemd::ServiceLimits] $limits`, so the parameter's type alias failed to resolve against the latest `puppet/systemd`, breaking the unit test. This led to a `"Resource type not found: Systemd::ServiceLimits"` error.

This PR switches to using `Systemd::Unit::Service`, the type `systemd::manage_dropin's service_entry` already expects. It is a superset of the old struct (still accepts LimitNOFILE/LimitNPROC etc.), so existing usage is unaffected. This type should have existed long enough to be from before the current `puppet/systemd` floor (>= 6.0.0). This shouldn't require a dependency bump, no breaking change.

#### This Pull Request (PR) fixes the following issues
Fixes #196 